### PR TITLE
Revert "feat(redis): update helm-release to v18.11.0" (#2441) bitnami/charts#22922

### DIFF
--- a/kubernetes/talos-flux/apps/database/redis/app/helm-release.yaml
+++ b/kubernetes/talos-flux/apps/database/redis/app/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
-      version: 18.11.0
+      version: 18.9.1
       sourceRef:
         kind: HelmRepository
         name: bitnami-charts


### PR DESCRIPTION
Reverts tyriis/home-ops#2437 because of bitnami/charts#22922