### PR TITLE
feat(minecraft): workaround for rcon velocity plugin problem

### DIFF
--- a/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/config/plugins.txt
+++ b/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/config/plugins.txt
@@ -1,3 +1,6 @@
+# RCON https://mvn.tribufu.com/#/releases/com/tribufu/Tribufu-VelocityRcon
+# workaround for https://github.com/itzg/docker-mc-proxy/issues/248
+https://mvn.tribufu.com/releases/com/tribufu/Tribufu-VelocityRcon/1.2.0/Tribufu-VelocityRcon-1.2.0.jar
 # geyser
 https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/velocity
 # floodgate

--- a/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/helm-release.yaml
+++ b/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/helm-release.yaml
@@ -53,9 +53,6 @@ spec:
             image:
               repository: itzg/mc-proxy
               tag: java21@sha256:02a50a98bc75687180e40a708af35b47714f6dda701ec4780f1281c799b61753
-            envFrom:
-              - secretRef:
-                  name: minecraft-rcon
             env:
               TZ: Europe/Vienna
               # for a full list of ENV vars see: https://github.com/itzg/docker-mc-proxy#environment-settings
@@ -72,7 +69,13 @@ spec:
               # JVM_XX_OPTS: "-XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch"
               JVM_XX_OPTS: "-XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15"
               ICON: "https://storage.googleapis.com/techtales-public-images/lava-chicken-icon.png"
-              ENABLE_RCON: "true"
+              ENABLE_RCON: "false"
+
+              CFG_RCON_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: minecraft-rcon
+                    key: RCON_PASSWORD
 
             securityContext:
               allowPrivilegeEscalation: false
@@ -210,4 +213,13 @@ spec:
             app:
               - path: /plugins/minimotd-velocity/main.conf
                 subPath: main.conf
+                readOnly: true
+      velocityrcon:
+        type: configMap
+        name: minecraft-public-velocity-proxy-plugins-velocityrcon
+        advancedMounts:
+          velocity:
+            app:
+              - path: /plugins/velocityrcon/rcon.toml
+                subPath: rcon.toml
                 readOnly: true

--- a/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/kustomization.yaml
+++ b/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/kustomization.yaml
@@ -17,6 +17,9 @@ configMapGenerator:
   - name: minecraft-public-velocity-proxy-plugins-minimotd
     files:
       - main.conf=plugins/minimotd-velocity/main.conf
+  - name: minecraft-public-velocity-proxy-plugins-velocityrcon
+    files:
+      - rcon.toml=plugins/velocityrcon/rcon.toml
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/plugins/velocityrcon/rcon.toml
+++ b/kubernetes/talos-flux/apps/gaming-public/minecraft-java/velocity-proxy/plugins/velocityrcon/rcon.toml
@@ -1,0 +1,4 @@
+rcon-host = "0.0.0.0"
+rcon-port = "25575"
+rcon-password = "${CFG_RCON_PASSWORD}"
+rcon-colored = false


### PR DESCRIPTION
- workaround for: itzg/docker-mc-proxy#248
- deactivate rcon and install via plugin system