### PR TITLE
fix(atlantis): remove github token and owner env vars

### DIFF
--- a/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/external-secret.patch.yaml
+++ b/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/external-secret.patch.yaml
@@ -17,10 +17,6 @@ spec:
       data:
         AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
         AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
-        GITHUB_OWNER: "{{ .GITHUB_OWNER }}"
-        GITHUB_APP_ID: "{{ .GITHUB_APP_ID }}"
-        GITHUB_APP_INSTALLATION_ID: "{{ .GITHUB_APP_INSTALLATION_ID }}"
-        GITHUB_APP_PEM_FILE: "{{ .GITHUB_APP_PEM_FILE }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/atlantis-system/${APP}


### PR DESCRIPTION
## Summary
- Removes `GITHUB_OWNER` and GitHub App authentication variables (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PEM_FILE`) from the `tyriis/terraform-github` ExternalSecret.
- The Terraform GitHub provider now reads the necessary token and owner directly from Vault during runtime instead of relying on environment variables injected via ExternalSecrets.

Fixes tyriis/terraform-github#505