### PR TITLE
fix(atlantis): hardcode vault role for tyriis github tyriis/terraform-github#505

### DIFF
--- a/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/config/vault_config.sh
+++ b/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/config/vault_config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# This script replaces the ATLANTIS_INJECT_VAULT_CONFIG marker with vault auth_login configuration
+
+# Define the replacement text
+replacement="auth_login {\n    path = \"auth/kube-lab/login\"\n    parameters = {\n      role = \"atlantis-tyriis-terraform-github\"\n      jwt  = file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")\n    }\n  }"
+
+# Find provider.tf files containing both "provider \"vault\"" and the marker
+for provider_file in $(grep -l 'provider "vault"' $(find . -name "provider.tf" -o -name "providers.tf") | xargs grep -l 'ATLANTIS_INJECT_VAULT_CONFIG'); do
+  echo "Found vault provider in $provider_file, injecting auth_login configuration..."
+
+  # Use sed to perform the replacement
+  sed -i "s|# ATLANTIS_INJECT_VAULT_CONFIG|$replacement|" "$provider_file"
+
+  echo "Successfully updated $provider_file"
+done

--- a/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/helm-release.patch.yaml
+++ b/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/helm-release.patch.yaml
@@ -46,6 +46,5 @@ spec:
         advancedMounts:
           main:
             app:
-              - path: /home/atlantis/scripts/vault_config.sh
-                subPath: vault_config.sh
+              - path: /home/atlantis/scripts
                 readOnly: true

--- a/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/helm-release.patch.yaml
+++ b/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/helm-release.patch.yaml
@@ -40,3 +40,12 @@ spec:
               - path: /etc/atlantis/repos.yaml
                 subPath: repos.yaml
                 readOnly: true
+      scripts:
+        type: configMap
+        name: ${APP}-scripts
+        advancedMounts:
+          main:
+            app:
+              - path: /home/atlantis/scripts/vault_config.sh
+                subPath: vault_config.sh
+                readOnly: true

--- a/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/kustomization.yaml
+++ b/kubernetes/main/apps/atlantis-system/tyriis/terraform-github/kustomization.yaml
@@ -11,6 +11,9 @@ configMapGenerator:
   - name: atlantis-tyriis-terraform-github-config
     files:
       - repos.yaml=./config/repos.yaml
+  - name: atlantis-tyriis-terraform-github-scripts
+    files:
+      - vault_config.sh=./config/vault_config.sh
 generatorOptions:
   disableNameSuffixHash: true
   annotations:


### PR DESCRIPTION
tyriis/terraform-github#505

Copy the default vault_config.sh script and hardcode the Vault role to atlantis-tyriis-terraform-github to fix the invalid role error during plan/apply. example: https://github.com/tyriis/terraform-github/pull/506