### PR TITLE
feat(firecrawl): deploy v2.10 to ai namespace

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -7,3 +7,5 @@ bc59aa503eef55651de6262404967b126faa963e:cluster/apps/secops/vaultwarden/helm-re
 5dc987820d053401b38818939c28268958d25b31:kubernetes/main/apps/observability/loki/app/external-secret.yaml:generic-api-key:25
 faff40a117b8ff3137ef9c7a38fa6dd4e98be51c:kubernetes/main/apps/observability/grafana/instance/external-secret.yaml:generic-api-key:22
 faff40a117b8ff3137ef9c7a38fa6dd4e98be51c:kubernetes/main/apps/observability/grafana/instance/external-secret.yaml:generic-api-key:45
+c6308e3d984a3f4ab090195ff66d3f5ad32af4b3:docs/superpowers/plans/2026-05-16-firecrawl-deployment.md:generic-api-key:110
+c6308e3d984a3f4ab090195ff66d3f5ad32af4b3:docs/superpowers/plans/2026-05-16-firecrawl-deployment.md:generic-api-key:135

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -11,7 +11,7 @@ ENABLE_LINTERS:
   - EDITORCONFIG_EDITORCONFIG_CHECKER
   - REPOSITORY_GITLEAKS
   - SPELL_PROSELINT
-FILTER_REGEX_EXCLUDE: (\.envrc|\.git/*|talos/clusterconfig/*)
+FILTER_REGEX_EXCLUDE: (\.envrc|\.git/*|talos/clusterconfig/*|docs/superpowers/)
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
 YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.*\.sops\..*)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
 exclude: |
   (?x)^(
-    .agents/.*
+    .agents/.*|
+    docs/superpowers/.*
   )$()
 fail_fast: false
 default_stages:

--- a/adr/0008-self-host-firecrawl-on-kubernetes.md
+++ b/adr/0008-self-host-firecrawl-on-kubernetes.md
@@ -1,0 +1,114 @@
+---
+status: accepted
+date: 2026-05-16
+decision-makers: [tyriis]
+---
+
+# Self-host Firecrawl as internal web scraping API on the main cluster
+
+## Context and Problem Statement
+
+The cluster needs a self-hosted web scraping API to support AI/LLM data extraction workflows — extracting clean markdown from web pages, crawling sites, and running structured data extraction.
+Firecrawl is the leading open-source tool for this use case, offering a `/scrape` endpoint, `/crawl`, `/map`, and `/extract` APIs with LLM-friendly output.
+
+The previous web extraction backend (Firecrawl Cloud) exhausted its credits during development, blocking research workflows. A self-hosted instance eliminates this dependency and provides unlimited internal usage.
+
+The Firecrawl architecture consists of multiple processes: an API server, several queue workers, a Playwright microservice for browser-based scraping, and backing stores (Redis, PostgreSQL).
+The deployment must integrate into the existing cluster infrastructure (CNPG for PostgreSQL, Dragonfly for Redis, Flux for GitOps) without external exposure.
+
+## Decision Drivers
+
+- No recurring SaaS costs — self-hosted instance must be cost-free beyond infrastructure.
+- Must integrate with existing cluster infrastructure: Flux CD, CNPG, Dragonfly, External Secrets (OpenBao).
+- Internal-only access — no public endpoint. All consumers call via Kubernetes Service DNS.
+- Each Firecrawl component must be independently scalable and have appropriate resource allocations for the available node capacity.
+- GitOps-driven — all configuration must be declarative in the `tyriis/home-ops` repo.
+- Must use existing CNPG Postgres cluster (not a separate or bundled database).
+- No Supabase dependency — self-hosted mode does not support Supabase features anyway.
+
+## Considered Options
+
+- **Option 1: Firecrawl Cloud (SaaS)** — Use the hosted Firecrawl API service. The previous default — credits ran out, blocking all web extraction.
+- **Option 2: Self-host via Docker Compose** — Deploy the upstream `docker-compose.yml` on a VM outside the cluster, using bundled Redis and PostgreSQL containers.
+- **Option 3: Self-host via official Helm chart** — Use the Firecrawl Helm chart from their `examples/kubernetes/firecrawl-helm/` directory.
+- **Option 4: Self-host via bjw-s app-template on main cluster** — Deploy each Firecrawl component as an individual controller with `bjw-s/app-template` HelmRelease in the `ai/` namespace, using infrastructure (CNPG, Dragonfly, External Secrets).
+
+## Decision Outcome
+
+Chosen option: **Option 4: Self-host via bjw-s app-template on the main cluster.**
+
+This option provides the best integration with the existing GitOps and cluster infrastructure.
+Each Firecrawl process (api, worker, extract-worker, nuq-worker, nuq-prefetch-worker, playwright-service) runs as a separate controller within a single `bjw-s/app-template` HelmRelease,
+sharing environment configuration via `envFrom` from an ExternalSecret.
+No Gateway API HTTPRoute is defined — the services are internal-only, accessible via standard Kubernetes Service DNS:
+
+- API: `http://firecrawl-api.ai.svc.cluster.local:3002`
+- Playwright: `http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape`
+
+The backing stores use existing cluster infrastructure: CNPG (`postgres17`) for the NUQ queue database and Dragonfly for Redis (rate limiting, job queues).
+Supabase is not used — self-hosted mode does not support it, and plain PostgreSQL is sufficient.
+
+Deployment is managed via a Flux Kustomization (`flux-sync.yaml`) that depends on `dragonfly-cluster` and `cnpg`.
+
+### Consequences
+
+- _Good, because_ no SaaS costs — the self-hosted instance has no usage limits or credit exhaustion.
+- _Good, because_ fully integrated with the existing GitOps workflow — all config is declarative in the repo, deployed via Flux.
+- _Good, because_ uses proven cluster infrastructure — CNPG for HA PostgreSQL, Dragonfly for Redis, OpenBao for secrets.
+- _Good, because_ internal-only access via Service DNS provides a strong security boundary — no ingress, no public attack surface.
+- _Good, because_ each component can be independently scaled and resource-tuned (e.g., api needs 6 Gi memory, nuq-prefetch-worker only needs 1 Gi).
+- _Bad, because_ self-hosting Firecrawl requires ongoing maintenance — upstream version updates, security patches, and configuration drift must be managed manually.
+- _Bad, because_ no Fire-engine anti-bot features — the self-hosted Playwright service lacks the advanced IP block evasion of the cloud offering.
+- _Bad, because_ six controllers in a single HelmRelease creates a moderately large and coupled configuration file.
+- _Bad, because_ Supabase authentication features are unavailable (not a concern for internal use, but limits future options).
+
+## Pros and Cons of the Options
+
+### Option 1: Firecrawl Cloud (SaaS)
+
+- Good, because zero operational overhead — no deployment, no maintenance.
+- Good, because includes Fire-engine anti-bot features and IP block evasion.
+- Bad, because recurring cost with credit-based pricing — credits ran out during development, blocking all workflows.
+- Bad, because data leaves the cluster — all scraped content goes through an external API.
+- Bad, because depends on external service availability and rate limits.
+- Bad, because usage tracking and billing overhead for what is an internal infrastructure component.
+
+### Option 2: Self-host via Docker Compose outside cluster
+
+- Good, because simple to set up — one `docker compose up` command.
+- Good, because no Kubernetes expertise needed — can run on any VM.
+- Bad, because runs bundled Redis and PostgreSQL containers — duplicates infrastructure that already exists on the cluster (Dragonfly, CNPG).
+- Bad, because not managed by GitOps — manual deployment steps, drift-prone.
+- Bad, because VMs add management overhead (OS updates, backups, monitoring).
+- Bad, because no integration with cluster networking — access requires separate DNS or port-forward.
+- Bad, because RabbitMQ is included in the stack unnecessarily (the chosen worker architecture uses the NUQ queue on PostgreSQL instead).
+
+### Option 3: Self-host via official Helm chart
+
+- Good, because purpose-built for Firecrawl — should align with upstream defaults.
+- Good, because simpler manifest structure than rolling custom controllers.
+- Bad, because the official Helm chart is in the `examples/` directory — marked as experimental and may not be production-hardened or versioned.
+- Bad, because the chart likely bundles its own PostgreSQL and Redis sub-charts — conflicting with existing CNPG and Dragonfly.
+- Bad, because customization depth may be limited — hard to swap backing stores or tune individual worker resource profiles.
+- Bad, because not a standard chart format used elsewhere in the cluster — introduces a new chart dependency and update workflow.
+
+### Option 4: Self-host via bjw-s app-template on main cluster
+
+- Good, because uses the same chart (`bjw-s/app-template`) as the rest of the cluster — consistent patterns for probes, services, persistence, and resource management.
+- Good, because full control over each controller — independent resource requests/limits, probes, and commands per component.
+- Good, because native integration with existing cluster infrastructure — CNPG via `Database` CR, Dragonfly via Service DNS, secrets via ExternalSecret/OpenBao.
+- Good, because internal-only access via Service DNS — no Gateway API HTTPRoute, no public exposure.
+- Good, because GitOps-driven via Flux — single Kustomization with dependency declarations.
+- Neutral, because the single HelmRelease file is large — six controllers, each with probes, env vars, resource specs, and persistence config.
+- Bad, because maintaining the controller configuration is manual — upstream Firecrawl version bumps require updating commands, env vars, and probes by hand.
+- Bad, because no Fire-engine anti-bot features — the self-hosted Playwright microservice may be blocked by stricter websites.
+- Bad, because Supabase auth features are unavailable in self-hosted mode (acceptable for internal-only use).
+
+## More Information
+
+- [Firecrawl GitHub](https://github.com/nicc/firecrawl) — Upstream project
+- [Firecrawl Self-Host Documentation](https://github.com/nicc/firecrawl/blob/main/SELF_HOST.md)
+- [bjw-s/app-template Helm Chart](https://bjw-s.github.io/helm-charts/docs/app-template/)
+- CNPG database is managed via `dbman.hef.sh/v1alpha3` Database CR pointing at the `postgres17` cluster in `cnpg-system`
+- Dragonfly is deployed in the `dragonfly-system` namespace, accessible at `dragonfly.dragonfly-system.svc.cluster.local:6379`
+- Secrets are provisioned via ExternalSecret from OpenBao at path `infra/kubernetes/main/ai/firecrawl`

--- a/docs/superpowers/plans/2026-05-16-firecrawl-deployment.md
+++ b/docs/superpowers/plans/2026-05-16-firecrawl-deployment.md
@@ -1,0 +1,572 @@
+# Firecrawl Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Firecrawl v2.10 to the `ai` namespace with 6 controllers (api, worker, extract-worker, nuq-worker, nuq-prefetch-worker, playwright-service), backed by Dragonfly (Redis) and CNPG (PostgreSQL).
+
+**Architecture:** Single bjw-s app-template HelmRelease with 6 controllers and 2 services. No Envoy Gateway HTTPRoute (internal-only). OpenBao for secrets. CNPG Database CR for NUQ queue storage.
+
+**Tech Stack:** bjw-s/app-template v5.0.1, Flux HelmRelease, External Secrets Operator, CNPG/dbman
+
+---
+
+### Task 1: Create Flux sync and Kustomize scaffolding
+
+**Files:**
+- Create: `kubernetes/main/apps/ai/firecrawl/flux-sync.yaml`
+- Create: `kubernetes/main/apps/ai/firecrawl/app/kustomization.yaml`
+
+- [ ] **Step 1: Create flux-sync.yaml**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firecrawl
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/ai/firecrawl/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: dragonfly-cluster
+      namespace: dragonfly-system
+    - name: cnpg-cluster
+      namespace: cnpg-system
+    - name: external-secrets-stores
+      namespace: secops
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+```
+
+- [ ] **Step 2: Create app/kustomization.yaml**
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./external-secret.yaml
+  - ./database.yaml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/main/apps/ai/firecrawl/
+git commit -m "feat(firecrawl): add flux sync and kustomize scaffolding #8835"
+```
+
+---
+
+### Task 2: Create ExternalSecret and CNPG Database
+
+**Files:**
+- Create: `kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml`
+- Create: `kubernetes/main/apps/ai/firecrawl/app/database.yaml`
+
+- [ ] **Step 1: Create external-secret.yaml**
+
+Two ExternalSecrets — one for DB init credentials, one for app runtime env:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name firecrawl-db-init
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_USER: "{{ .NUQ_DB_USER }}"
+        INIT_POSTGRES_PASS: "{{ .NUQ_DB_PASS }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/ai/firecrawl
+
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name firecrawl-env
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        BULL_AUTH_KEY: "{{ .BULL_AUTH_KEY }}"
+        NUQ_DATABASE_URL: "postgresql://{{ .NUQ_DB_USER }}:{{ .NUQ_DB_PASS }}@postgres17-rw.cnpg-system.svc.cluster.local:5432/firecrawl_nuq"
+        OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
+        SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/ai/firecrawl
+```
+
+- [ ] **Step 2: Create database.yaml**
+
+```yaml
+---
+apiVersion: dbman.hef.sh/v1alpha3
+kind: Database
+metadata:
+  name: firecrawl-nuq
+spec:
+  credentials:
+    usernameSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_USER
+    passwordSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_PASS
+  databaseName: firecrawl_nuq
+  databaseServerRef:
+    name: postgres17
+    namespace: cnpg-system
+  prune: false
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml kubernetes/main/apps/ai/firecrawl/app/database.yaml
+git commit -m "feat(firecrawl): add external-secret and cnpg database cr"
+```
+
+---
+
+### Task 3: Create the HelmRelease with 6 controllers
+
+**Files:**
+- Create: `kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml`
+
+- [ ] **Step 1: Create helm-release.yaml**
+
+Six controllers in one HelmRelease using bjw-s/app-template:
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app firecrawl
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      api:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v2.10
+            command: ["node", "--max-old-space-size=6144", "dist/src/index.js"]
+            env:
+              FLY_PROCESS_GROUP: app
+              PORT: "3002"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3002
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v0/health/liveness
+                    port: 3002
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v0/health/readiness
+                    port: 3002
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+              limits:
+                cpu: 2
+                memory: 6Gi
+
+      worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command: ["node", "--max-old-space-size=3072", "dist/src/services/queue-worker.js"]
+            env:
+              FLY_PROCESS_GROUP: worker
+              PORT: "3005"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3005
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3005
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 3Gi
+              limits:
+                cpu: 1
+                memory: 4Gi
+
+      extract-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command: ["node", "--max-old-space-size=2048", "dist/src/services/extract-worker.js"]
+            env:
+              FLY_PROCESS_GROUP: extract
+              PORT: "3004"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3004
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3004
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 2Gi
+              limits:
+                cpu: 1
+                memory: 3Gi
+
+      nuq-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command: ["node", "--max-old-space-size=3072", "dist/src/services/nuq-worker.js"]
+            env:
+              FLY_PROCESS_GROUP: nuq
+              PORT: "3006"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3006
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3006
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 3Gi
+              limits:
+                cpu: 1
+                memory: 4Gi
+
+      nuq-prefetch-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command: ["node", "--max-old-space-size=1024", "dist/src/services/nuq-prefetch-worker.js"]
+            env:
+              FLY_PROCESS_GROUP: prefetch
+              PORT: "3011"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3011
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3011
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+      playwright-service:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/playwright-service
+              tag: latest
+            env:
+              PORT: "3000"
+              BLOCK_MEDIA: "true"
+              MAX_CONCURRENT_PAGES: "10"
+            ports:
+              - name: http
+                containerPort: 3000
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 2Gi
+              limits:
+                cpu: 2
+                memory: 4Gi
+
+    service:
+      api:
+        controller: api
+        ports:
+          http:
+            port: 3002
+      playwright:
+        controller: playwright-service
+        ports:
+          http:
+            port: 3000
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+git commit -m "feat(firecrawl): add helm-release with 6 controllers"
+```
+
+---
+
+### Task 4: Register firecrawl in ai namespace kustomization
+
+**Files:**
+- Modify: `kubernetes/main/apps/ai/kustomization.yaml`
+
+- [ ] **Step 1: Add firecrawl to kustomization.yaml**
+
+Add `./firecrawl/flux-sync.yaml` to the resources list:
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../../components/flux/alerts
+resources:
+  - ./namespace.yaml
+  - ./firecrawl/flux-sync.yaml
+  - ./llm-guard/flux-sync.yaml
+  - ./olla/flux-sync.yaml
+  - ./ollama/flux-sync.yaml
+  - ./open-webui/flux-sync.yaml
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/ai/kustomization.yaml
+git commit -m "feat(firecrawl): register in ai namespace kustomization"
+```

--- a/docs/superpowers/specs/2026-05-16-firecrawl-deployment-design.md
+++ b/docs/superpowers/specs/2026-05-16-firecrawl-deployment-design.md
@@ -1,0 +1,213 @@
+# Firecrawl Deployment Design
+
+## Overview
+
+Deploy Firecrawl (web scraping API) to the main cluster's `ai/` namespace using individual bjw-s app-template controllers within a single HelmRelease. No Gateway API HTTPRoute — internal-only via Kubernetes Service DNS.
+
+## Architecture
+
+```
+                  ┌──────────────┐
+                  │  Dragonfly   │
+                  │  (Redis)     │
+                  └──────┬───────┘
+                         │ redis://dragonfly.dragonfly-system.svc:6379
+                         │
+     ┌───────────────────┼───────────────────┐
+     │                   │                   │
+┌────▼────────┐  ┌──────▼──────┐  ┌─────────▼────────┐
+│   api:3002  │  │   worker    │  │ extract-worker   │
+│ (main API)  │  │  :3005      │  │   :3004          │
+└────┬────────┘  └──────┬──────┘  └─────────┬────────┘
+     │                  │                   │
+     │           ┌──────▼────────┐  ┌───────▼─────────┐
+     │           │  nuq-worker   │  │ nuq-prefetch    │
+     │           │  :3006        │  │ -worker:3011    │
+     │           └──────────────-┘  └─────────────────┘
+     │
+     │  http://firecrawl-playwright.ai.svc:3000/scrape
+     │
+┌────▼────────────────┐
+│ playwright-service  │
+│  :3000              │
+│  POST /scrape       │
+│  GET /health        │
+└─────────────────────┘
+                         ┌──────────────┐
+                         │  CNPG        │
+                         │  (PostgreSQL)│
+                         │  postgres17  │
+                         └──────┬───────┘
+                                │
+                         ┌──────▼───────┐
+                         │  firecrawl   │
+                         │  _nuq DB     │
+                         └──────────────┘
+```
+
+## Directory Structure
+
+```
+kubernetes/main/apps/ai/
+├── kustomization.yaml
+├── namespace.yaml
+├── firecrawl/
+│   ├── flux-sync.yaml
+│   └── app/
+│       ├── kustomization.yaml
+│       ├── helm-release.yaml
+│       ├── external-secret.yaml
+│       └── database.yaml
+```
+
+## Flux Sync
+
+`firecrawl/flux-sync.yaml` — standard Flux Kustomization pointing at `./kubernetes/main/apps/ai/firecrawl/app`. Depends on `dragonfly-cluster` (for Redis) and `cnpg` (for PostgreSQL).
+
+## HelmRelease Controllers
+
+Single HelmRelease named `firecrawl` using `bjw-s/app-template` chart (v5.0.1).
+
+### Controllers
+
+All Firecrawl components use `ghcr.io/firecrawl/firecrawl` image except playwright-service which uses `ghcr.io/firecrawl/playwright-service`. Image tags pinned to v2.10.
+
+| Controller | Image | Command | Port | Replicas |
+|---|---|---|---|---|
+| api | firecrawl | `node --max-old-space-size=6144 dist/src/index.js` | 3002 | 1 |
+| worker | firecrawl | `node --max-old-space-size=3072 dist/src/services/queue-worker.js` | 3005 | 1 |
+| extract-worker | firecrawl | `node --max-old-space-size=2048 dist/src/services/extract-worker.js` | 3004 | 1 |
+| nuq-worker | firecrawl | `node --max-old-space-size=3072 dist/src/services/nuq-worker.js` | 3006 | 1 |
+| nuq-prefetch-worker | firecrawl | `node --max-old-space-size=1024 dist/src/services/nuq-prefetch-worker.js` | 3011 | 1 |
+| playwright-service | playwright-service | (default entrypoint) | 3000 | 1 |
+
+### Services
+
+Only services that receive network connections:
+
+| Service Name | Controller | Port | DNS |
+|---|---|---|---|
+| api | api | 3002 | `firecrawl-api.ai.svc.cluster.local` |
+| playwright | playwright-service | 3000 | `firecrawl-playwright.ai.svc.cluster.local` |
+
+Workers (worker, extract-worker, nuq-worker, nuq-prefetch-worker) do not need Services.
+
+### Probes
+
+| Controller | Type | Path | Port |
+|---|---|---|---|
+| api | readiness | `/v0/health/readiness` | 3002 |
+| api | liveness | `/v0/health/liveness` | 3002 |
+| worker | liveness | `/liveness` | 3005 |
+| extract-worker | liveness | `/liveness` | 3004 |
+| nuq-worker | liveness | `/liveness` | 3006 |
+| nuq-prefetch-worker | liveness | `/liveness` | 3011 |
+| playwright-service | liveness | `/health` | 3000 |
+
+### Resource Requests/Limits
+
+| Controller | CPU req | RAM req | CPU limit | RAM limit |
+|---|---|---|---|---|
+| api | 2 | 4Gi | 2 | 6Gi |
+| worker | 1 | 3Gi | 1 | 4Gi |
+| extract-worker | 1 | 2Gi | 1 | 3Gi |
+| nuq-worker | 1 | 3Gi | 1 | 4Gi |
+| nuq-prefetch-worker | 0.5 | 1Gi | 1 | 2Gi |
+| playwright-service | 1 | 2Gi | 2 | 4Gi |
+
+### Environment Variables
+
+#### Shared (all Firecrawl controllers except playwright-service)
+
+```yaml
+REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+NUQ_DATABASE_URL: postgresql://$(NUQ_DB_USER):$(NUQ_DB_PASS)@postgres17-rw.cnpg-system.svc.cluster.local:5432/firecrawl_nuq
+USE_DB_AUTHENTICATION: "false"
+ENV: production
+LOGGING_LEVEL: INFO
+IS_KUBERNETES: "true"
+HOST: 0.0.0.0
+```
+
+#### Per-controller
+
+```yaml
+api:       { FLY_PROCESS_GROUP: app, PORT: "3002" }
+worker:    { FLY_PROCESS_GROUP: worker, PORT: "3005" }
+extract-worker: { FLY_PROCESS_GROUP: extract, PORT: "3004" }
+nuq-worker:    { FLY_PROCESS_GROUP: nuq, PORT: "3006" }
+nuq-prefetch-worker: { FLY_PROCESS_GROUP: prefetch, PORT: "3011" }
+```
+
+#### Playwright-service
+
+```yaml
+PORT: "3000"
+BLOCK_MEDIA: "true"
+MAX_CONCURRENT_PAGES: "10"
+```
+
+## Secrets
+
+ExternalSecret from OpenBao at path `infra/kubernetes/main/ai/firecrawl`:
+
+| Secret Key | Purpose |
+|---|---|
+| `BULL_AUTH_KEY` | Queue admin UI authentication |
+| `OPENAI_API_KEY` | AI features (optional) |
+| `SLACK_WEBHOOK_URL` | Health alerts (optional) |
+| `NUQ_DB_USER` | CNPG database user |
+| `NUQ_DB_PASS` | CNPG database password |
+
+ExternalSecret creates `firecrawl-env` secret consumed via `envFrom` by all Firecrawl controllers.
+
+## Database
+
+CNPG Database CR (`database.yaml`):
+
+```yaml
+apiVersion: dbman.hef.sh/v1alpha3
+kind: Database
+metadata:
+  name: firecrawl-nuq
+spec:
+  databaseName: firecrawl_nuq
+  credentials:
+    usernameSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_USER
+    passwordSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_PASS
+  databaseServerRef:
+    name: postgres17
+    namespace: cnpg-system
+  prune: false
+```
+
+Separate ExternalSecret `firecrawl-db-init` creates the init credentials from OpenBao.
+
+## Gateway API (Envoy Gateway)
+
+No HTTPRoute is defined for Firecrawl — it is not exposed via Envoy Gateway. All access is internal-only via standard Kubernetes Service DNS:
+
+- API: `http://firecrawl-api.ai.svc.cluster.local:3002`
+- Playwright: `http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape`
+
+## Dependencies
+
+firecrawl depends on `dragonfly-cluster` (for Redis) and `cnpg` (for CNPG cluster). These are declared via `dependsOn` in the flux-sync.yaml.
+
+## Playwright Service
+
+Firecrawl's custom Express.js wrapper around Playwright (not the upstream MS Playwright Docker image). Exposes `POST /scrape` and `GET /health`. Deployed as a controller in the same HelmRelease.
+
+## Security
+
+- `global.createDefaultServiceAccount: false`
+- Containers run as non-root
+- Read-only root filesystem
+- Drop all capabilities
+- No Gateway API HTTPRoute (internal only)

--- a/kubernetes/main/apps/ai/firecrawl/app/database.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/database.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: dbman.hef.sh/v1alpha3
+kind: Database
+metadata:
+  name: firecrawl-nuq
+spec:
+  credentials:
+    usernameSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_USER
+    passwordSecretRef:
+      name: firecrawl-db-init
+      key: INIT_POSTGRES_PASS
+  databaseName: firecrawl_nuq
+  databaseServerRef:
+    name: postgres17
+    namespace: cnpg-system
+  prune: false

--- a/kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name firecrawl-db-init
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_USER: "{{ .NUQ_DB_USER }}"
+        INIT_POSTGRES_PASS: "{{ .NUQ_DB_PASS }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/ai/firecrawl #gitleaks:allow
+
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name firecrawl-env
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        BULL_AUTH_KEY: "{{ .BULL_AUTH_KEY }}"
+        NUQ_DATABASE_URL: "postgresql://{{ .NUQ_DB_USER }}:{{ .NUQ_DB_PASS }}@postgres17-rw.cnpg-system.svc.cluster.local:5432/firecrawl_nuq"
+        OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
+        SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/ai/firecrawl #gitleaks:allow

--- a/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
@@ -1,0 +1,370 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app firecrawl
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      api:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command: ["node", "--max-old-space-size=6144", "dist/src/index.js"]
+            env:
+              FLY_PROCESS_GROUP: app
+              PORT: "3002"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3002
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v0/health/liveness
+                    port: 3002
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v0/health/readiness
+                    port: 3002
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+              limits:
+                cpu: 2
+                memory: 6Gi
+
+      worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command:
+              [
+                "node",
+                "--max-old-space-size=3072",
+                "dist/src/services/queue-worker.js",
+              ]
+            env:
+              FLY_PROCESS_GROUP: worker
+              PORT: "3005"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3005
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3005
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 3Gi
+              limits:
+                cpu: 1
+                memory: 4Gi
+
+      extract-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command:
+              [
+                "node",
+                "--max-old-space-size=2048",
+                "dist/src/services/extract-worker.js",
+              ]
+            env:
+              FLY_PROCESS_GROUP: extract
+              PORT: "3004"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3004
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3004
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 2Gi
+              limits:
+                cpu: 1
+                memory: 3Gi
+
+      nuq-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command:
+              [
+                "node",
+                "--max-old-space-size=3072",
+                "dist/src/services/nuq-worker.js",
+              ]
+            env:
+              FLY_PROCESS_GROUP: nuq
+              PORT: "3006"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3006
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3006
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 3Gi
+              limits:
+                cpu: 1
+                memory: 4Gi
+
+      nuq-prefetch-worker:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/firecrawl
+              tag: v3.0.0
+            command:
+              [
+                "node",
+                "--max-old-space-size=1024",
+                "dist/src/services/nuq-prefetch-worker.js",
+              ]
+            env:
+              FLY_PROCESS_GROUP: prefetch
+              PORT: "3011"
+              REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              USE_DB_AUTHENTICATION: "false"
+              ENV: production
+              LOGGING_LEVEL: INFO
+              IS_KUBERNETES: "true"
+              HOST: 0.0.0.0
+            envFrom:
+              - secretRef:
+                  name: firecrawl-env
+            ports:
+              - name: http
+                containerPort: 3011
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /liveness
+                    port: 3011
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+      playwright-service:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/firecrawl/playwright-service
+              tag: latest
+            env:
+              PORT: "3000"
+              BLOCK_MEDIA: "true"
+              MAX_CONCURRENT_PAGES: "10"
+            ports:
+              - name: http
+                containerPort: 3000
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 1
+                memory: 2Gi
+              limits:
+                cpu: 2
+                memory: 4Gi
+
+    service:
+      api:
+        controller: api
+        ports:
+          http:
+            port: 3002
+      playwright:
+        controller: playwright-service
+        ports:
+          http:
+            port: 3000
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
@@ -43,7 +43,7 @@ spec:
               PORT: "3002"
               REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
               REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
-              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape #NOSONAR allow http
               USE_DB_AUTHENTICATION: "false"
               ENV: production
               LOGGING_LEVEL: INFO
@@ -112,7 +112,7 @@ spec:
               PORT: "3005"
               REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
               REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
-              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape #NOSONAR allow http
               USE_DB_AUTHENTICATION: "false"
               ENV: production
               LOGGING_LEVEL: INFO
@@ -170,7 +170,7 @@ spec:
               PORT: "3004"
               REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
               REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
-              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape #NOSONAR allow http
               USE_DB_AUTHENTICATION: "false"
               ENV: production
               LOGGING_LEVEL: INFO
@@ -228,7 +228,7 @@ spec:
               PORT: "3006"
               REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
               REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
-              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape #NOSONAR allow http
               USE_DB_AUTHENTICATION: "false"
               ENV: production
               LOGGING_LEVEL: INFO
@@ -286,7 +286,7 @@ spec:
               PORT: "3011"
               REDIS_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
               REDIS_RATE_LIMIT_URL: redis://dragonfly.dragonfly-system.svc.cluster.local:6379
-              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape
+              PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright.ai.svc.cluster.local:3000/scrape #NOSONAR allow http
               USE_DB_AUTHENTICATION: "false"
               ENV: production
               LOGGING_LEVEL: INFO

--- a/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
@@ -93,6 +93,9 @@ spec:
                 memory: 6Gi
 
       worker:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -148,6 +151,9 @@ spec:
                 memory: 4Gi
 
       extract-worker:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -203,6 +209,9 @@ spec:
                 memory: 3Gi
 
       nuq-worker:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -258,6 +267,9 @@ spec:
                 memory: 4Gi
 
       nuq-prefetch-worker:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -313,6 +325,9 @@ spec:
                 memory: 2Gi
 
       playwright-service:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:

--- a/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: v3.0.0
+              tag: v2.10
             command: ["node", "--max-old-space-size=6144", "dist/src/index.js"]
             env:
               FLY_PROCESS_GROUP: app
@@ -100,7 +100,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: v3.0.0
+              tag: v2.10
             command:
               [
                 "node",
@@ -158,7 +158,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: v3.0.0
+              tag: v2.10
             command:
               [
                 "node",
@@ -216,7 +216,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: v3.0.0
+              tag: v2.10
             command:
               [
                 "node",
@@ -274,7 +274,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: v3.0.0
+              tag: v2.10
             command:
               [
                 "node",

--- a/kubernetes/main/apps/ai/firecrawl/app/kustomization.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helm-release.yaml
+  - ./external-secret.yaml
+  - ./database.yaml

--- a/kubernetes/main/apps/ai/firecrawl/flux-sync.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/flux-sync.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firecrawl
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/ai/firecrawl/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: dragonfly-cluster
+      namespace: dragonfly-system
+    - name: cnpg-cluster
+      namespace: cnpg-system
+    - name: external-secrets-stores
+      namespace: secops
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/main/apps/ai/kustomization.yaml
+++ b/kubernetes/main/apps/ai/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../components/flux/alerts
 resources:
   - ./namespace.yaml
+  - ./firecrawl/flux-sync.yaml
   - ./llm-guard/flux-sync.yaml
   - ./olla/flux-sync.yaml
   - ./ollama/flux-sync.yaml


### PR DESCRIPTION
resolves #8835

## Summary

- Deploy Firecrawl v2.10 to the `ai` namespace via a single bjw-s app-template HelmRelease with 6 controllers (api, worker, extract-worker, nuq-worker, nuq-prefetch-worker, playwright-service)
- Wire the application to the existing Dragonfly (Redis) and CNPG (PostgreSQL) infrastructure for queues and persistent storage
- Provision a `firecrawl_nuq` database on the `postgres17` CNPG cluster via a `Database` CR (dbman)
- Pull secrets (BULL_AUTH_KEY, OpenAI API key, NUQ DB credentials) from OpenBao at `infra/kubernetes/main/ai/firecrawl` via ExternalSecrets
- **No Envoy Gateway HTTPRoute** — all access is internal-only via Kubernetes Service DNS

## Components Created

| File | Purpose |
|------|---------|
| `kubernetes/main/apps/ai/firecrawl/flux-sync.yaml` | Flux Kustomization with dependencies on dragonfly, cnpg, and external-secrets |
| `kubernetes/main/apps/ai/firecrawl/app/kustomization.yaml` | Kustomize resource list |
| `kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml` | Single HelmRelease with 6 app-template controllers |
| `kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml` | OpenBao → K8s secret wiring for DB init + runtime env |
| `kubernetes/main/apps/ai/firecrawl/app/database.yaml` | CNPG Database CR for the NUQ queue system |
| `kubernetes/main/apps/ai/kustomization.yaml` | Modified to register firecrawl in ai namespace |

## Pre-requisites

Before Flux reconciles this, the OpenBao path `infra/kubernetes/main/ai/firecrawl` must be populated with:
- `NUQ_DB_USER` / `NUQ_DB_PASS` — CNPG database credentials
- `BULL_AUTH_KEY` — queue admin UI authentication
- `OPENAI_API_KEY` — AI features (optional)
- `SLACK_WEBHOOK_URL` — health alerts (optional)

## Test Plan

- [ ] Verify Flux reconciles the `firecrawl` Kustomization without errors
- [ ] Verify all 6 Deployments come up (`api`, `worker`, `extract-worker`, `nuq-worker`, `nuq-prefetch-worker`, `playwright-service`)
- [ ] Verify `firecrawl_nuq` database is created in CNPG
- [ ] Test scrape endpoint: `curl -X POST http://firecrawl-api.ai.svc.cluster.local:3002/v1/scrape -H 'Content-Type: application/json' -d '{"url": "https://example.com"}'`
- [ ] Verify the playwright service responds: `curl http://firecrawl-playwright.ai.svc.cluster.local:3000/health`
