### PR TITLE
fix(firecrawl): comment out optional OpenBao secrets until populated

### DIFF
--- a/kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/external-secret.yaml
@@ -40,8 +40,8 @@ spec:
       data:
         BULL_AUTH_KEY: "{{ .BULL_AUTH_KEY }}"
         NUQ_DATABASE_URL: "postgresql://{{ .NUQ_DB_USER }}:{{ .NUQ_DB_PASS }}@postgres17-rw.cnpg-system.svc.cluster.local:5432/firecrawl_nuq"
-        OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
-        SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
+        # OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
+        # SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/ai/firecrawl #gitleaks:allow


### PR DESCRIPTION
## Summary

Comment out `OPENAI_API_KEY` and `SLACK_WEBHOOK_URL` in the `firecrawl-env` ExternalSecret until those values are populated in OpenBao.

These are optional env vars - the app works without them.