### PR TITLE
fix(firecrawl): fix nuq-postgres user permissions and add data persistence

### DIFF
--- a/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/firecrawl/app/helm-release.yaml
@@ -254,6 +254,9 @@ spec:
 
       nuq-postgres:
         replicas: 1
+        pod:
+          securityContext:
+            fsGroup: 999
         containers:
           app:
             image:
@@ -266,6 +269,13 @@ spec:
             ports:
               - name: postgres
                 containerPort: 5432
+            securityContext:
+              runAsUser: 999
+              runAsGroup: 999
+              runAsNonRoot: true
+              capabilities:
+                drop:
+                  - ALL
             resources:
               requests:
                 cpu: 250m
@@ -296,6 +306,12 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      data:
+        type: emptyDir
+        advancedMounts:
+          nuq-postgres:
+            app:
+              - path: /var/lib/postgresql/data
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Summary

- Fix nuq-postgres security context: override `runAsUser: 1000` with postgres UID 999 so the container can write to its data directory
- Add `fsGroup: 999` at pod level for volume ownership
- Add `data` emptyDir persistence mounted at `/var/lib/postgresql/data`

Fixes the crashing nuq-postgres pod that prevented workers from connecting to the database.

Related: #8835