### PR TITLE
feat(secops): deploy talosctl-oidc for Pocket-ID authenticated read-only Talos access

### DIFF
--- a/kubernetes/main/apps/secops/kustomization.yaml
+++ b/kubernetes/main/apps/secops/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./namespace.yaml
   - ./rbac.yaml
   - ./external-secrets/flux-sync.yaml
+  - ./talosctl-oidc/flux-sync.yaml

--- a/kubernetes/main/apps/secops/talosctl-oidc/app/external-secret.yaml
+++ b/kubernetes/main/apps/secops/talosctl-oidc/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name talosctl-oidc-ca
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ca.crt: "{{ .ca_crt }}"
+        ca.key: "{{ .ca_key }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/secops/talosctl-oidc

--- a/kubernetes/main/apps/secops/talosctl-oidc/app/helm-release.yaml
+++ b/kubernetes/main/apps/secops/talosctl-oidc/app/helm-release.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app talosctl-oidc
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      createDefaultServiceAccount: false
+    controllers:
+      talosctl-oidc:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/qjoly/talosctl-oidc-server
+              tag: 0.0.4@sha256:ff55155e0f0af646239815bc3e015cb22cfaf05472b0a5e58dc8c22b12a60baa
+            command: ["/talosctl-oidc", "serve"]
+            env:
+              TALOSCTL_OIDC_ISSUER_URL: https://id.techtales.io
+              TALOSCTL_OIDC_CLIENT_ID: <CLIENT_ID>
+              TALOSCTL_OIDC_ENDPOINTS: "192.168.100.101,192.168.100.102,192.168.100.103"
+              TALOSCTL_OIDC_CERT_TTL: 60m
+              TALOSCTL_OIDC_ROLES: os:reader
+              TALOSCTL_OIDC_LISTEN: ":8443"
+              TALOSCTL_OIDC_DATA_DIR: /data
+              TALOSCTL_OIDC_CA_CERT: /config/ca.crt
+              TALOSCTL_OIDC_CA_KEY: /config/ca.key
+            ports:
+              - name: https
+                containerPort: &port 8443
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+        pod:
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: *app
+        type: LoadBalancer
+        ports:
+          https:
+            port: 8443
+    persistence:
+      config:
+        type: secret
+        name: talosctl-oidc-ca
+        globalMounts:
+          - path: /config
+            readOnly: true
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data

--- a/kubernetes/main/apps/secops/talosctl-oidc/app/kustomization.yaml
+++ b/kubernetes/main/apps/secops/talosctl-oidc/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./external-secret.yaml
+  - ./helm-release.yaml

--- a/kubernetes/main/apps/secops/talosctl-oidc/flux-sync.yaml
+++ b/kubernetes/main/apps/secops/talosctl-oidc/flux-sync.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app talosctl-oidc
+spec:
+  targetNamespace: secops
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/secops/talosctl-oidc/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: secops

--- a/kubernetes/utility/apps/secops/kustomization.yaml
+++ b/kubernetes/utility/apps/secops/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./external-secrets/flux-sync.yaml
   - ./openbao/flux-sync.yaml
   - ./pocket-id/flux-sync.yaml
+  - ./talosctl-oidc/flux-sync.yaml

--- a/kubernetes/utility/apps/secops/talosctl-oidc/app/external-secret.yaml
+++ b/kubernetes/utility/apps/secops/talosctl-oidc/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name talosctl-oidc-ca
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ca.crt: "{{ .ca_crt }}"
+        ca.key: "{{ .ca_key }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/utility/secops/talosctl-oidc

--- a/kubernetes/utility/apps/secops/talosctl-oidc/app/helm-release.yaml
+++ b/kubernetes/utility/apps/secops/talosctl-oidc/app/helm-release.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app talosctl-oidc
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      createDefaultServiceAccount: false
+    controllers:
+      talosctl-oidc:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/qjoly/talosctl-oidc-server
+              tag: 0.0.4@sha256:ff55155e0f0af646239815bc3e015cb22cfaf05472b0a5e58dc8c22b12a60baa
+            command: ["/talosctl-oidc", "serve"]
+            env:
+              TALOSCTL_OIDC_ISSUER_URL: https://id.techtales.io
+              TALOSCTL_OIDC_CLIENT_ID: <CLIENT_ID>
+              TALOSCTL_OIDC_ENDPOINTS: "192.168.100.31"
+              TALOSCTL_OIDC_CERT_TTL: 60m
+              TALOSCTL_OIDC_ROLES: os:reader
+              TALOSCTL_OIDC_LISTEN: ":8443"
+              TALOSCTL_OIDC_DATA_DIR: /data
+              TALOSCTL_OIDC_CA_CERT: /config/ca.crt
+              TALOSCTL_OIDC_CA_KEY: /config/ca.key
+            ports:
+              - name: https
+                containerPort: &port 8443
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+        pod:
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: *app
+        type: LoadBalancer
+        ports:
+          https:
+            port: 8443
+    persistence:
+      config:
+        type: secret
+        name: talosctl-oidc-ca
+        globalMounts:
+          - path: /config
+            readOnly: true
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data

--- a/kubernetes/utility/apps/secops/talosctl-oidc/app/kustomization.yaml
+++ b/kubernetes/utility/apps/secops/talosctl-oidc/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./external-secret.yaml
+  - ./helm-release.yaml

--- a/kubernetes/utility/apps/secops/talosctl-oidc/flux-sync.yaml
+++ b/kubernetes/utility/apps/secops/talosctl-oidc/flux-sync.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app talosctl-oidc
+spec:
+  targetNamespace: secops
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/utility/apps/secops/talosctl-oidc/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: secops


### PR DESCRIPTION
Draft PR for implementing Talos OIDC read-only access via Pocket-ID.

## Changes

### New: talosctl-oidc deployment (main + utility clusters)
- bjw-s app-template HelmRelease with talosctl-oidc-server
- ExternalSecret pulling Talos API CA from OpenBao
- LoadBalancer Service (Cilium L2, IP pool 192.168.100.200-250)
- Health probes, Reloader annotation, read-only root FS

### Pocket-ID OIDC client
- New public client `talosctl` in terraform-pocket-id repo
- PKCE enabled, callback http://127.0.0.1:8900/callback

### Manual steps remaining
1. Create the Pocket-ID OIDC client via terraform-pocket-id
2. Extract Talos API CA from each cluster and store in OpenBao
3. Store client_id in OpenBao alongside CA
4. Deploy and verify

Ref: <TODO>