### PR TITLE
feat(hermes-agent): deploy hermes-agent for multi-tenancy

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name ${APP}-secret
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        API_SERVER_KEY: "{{ .API_SERVER_KEY }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/hermes-agent/${APP}

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ${APP}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      hermes:
+        forceRename: *app
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
+            env:
+              PORT: "8642"
+              API_SERVER_ENABLED: "true"
+            envFrom:
+              - secretRef:
+                  name: ${APP}-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        forceRename: *app
+        primary: true
+        controller: hermes
+        ports:
+          http:
+            port: 8642
+    persistence:
+      data:
+        existingClaim: ${APP}-data
+        advancedMounts:
+          hermes:
+            app:
+              - path: /data
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          hermes:
+            app:
+              - path: /tmp

--- a/kubernetes/main/apps/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./external-secret.yaml
+  - ./helm-release.yaml
+  - ./network-policy.yaml

--- a/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/networkpolicy.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${APP}-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow incoming traffic only from open-webui in the ai namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ai
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+      ports:
+        - protocol: TCP
+          port: 8642
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow Internet egress but drop internal clusters to enforce isolation
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16

--- a/kubernetes/main/apps/hermes-agent/flux-sync.yaml
+++ b/kubernetes/main/apps/hermes-agent/flux-sync.yaml
@@ -1,0 +1,131 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-agent-tyriis
+spec:
+  targetNamespace: hermes-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  path: ./kubernetes/main/apps/hermes-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: volsync
+      namespace: backup-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SUFFIX: data
+
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-agent-jazzlyn
+spec:
+  targetNamespace: hermes-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  path: ./kubernetes/main/apps/hermes-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: volsync
+      namespace: backup-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SUFFIX: data
+
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-agent-crowlex
+spec:
+  targetNamespace: hermes-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  path: ./kubernetes/main/apps/hermes-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: volsync
+      namespace: backup-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SUFFIX: data
+
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-agent-techinik
+spec:
+  targetNamespace: hermes-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  path: ./kubernetes/main/apps/hermes-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: volsync
+      namespace: backup-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SUFFIX: data

--- a/kubernetes/main/apps/hermes-agent/kustomization.yaml
+++ b/kubernetes/main/apps/hermes-agent/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes-agent
+components:
+  - ../../../components/flux/alerts
+resources:
+  - ./namespace.yaml
+  - ./flux-sync.yaml

--- a/kubernetes/main/apps/hermes-agent/namespace.yaml
+++ b/kubernetes/main/apps/hermes-agent/namespace.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/namespace.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-agent
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
- Deploys hermes-agent for tyriis, jazzlyn, crowlex, and techinik.
- Utilizes parameterized HelmRelease with bjw-s/app-template.
- Enforces strict Cilium NetworkPolicy and non-root security context.
- Provisions isolated MinIO backup workflows using VolSync.

## OpenBao Secrets Required
You must create 4 separate secrets in OpenBao (one for each tenant's `API_SERVER_KEY`).
Path pattern: `infra/kubernetes/main/hermes-agent/<tenant-name>`

* `infra/kubernetes/main/hermes-agent/hermes-agent-tyriis`
* `infra/kubernetes/main/hermes-agent/hermes-agent-jazzlyn`
* `infra/kubernetes/main/hermes-agent/hermes-agent-crowlex`
* `infra/kubernetes/main/hermes-agent/hermes-agent-techinik`

Each secret needs a key named `API_SERVER_KEY`.

## Test Plan
- [x] Create the 4 secrets in OpenBao.
- [ ] Ensure Flux reconciles the Kustomization correctly.
- [ ] Check hermes-agent pods to confirm they spin up and bind to correct PVCs.
