### PR TITLE
fix(hermes-agent): run gateway command and bind to 0.0.0.0

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -41,14 +41,14 @@ spec:
           reloader.stakater.com/auto: "true"
         containers:
           app:
-            tty: true
-            stdin: true
+            command: ["gateway", "run"]
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
             env:
               PORT: "8642"
               API_SERVER_ENABLED: "true"
+              API_SERVER_HOST: "0.0.0.0"
             envFrom:
               - secretRef:
                   name: ${APP}-secret

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -41,6 +41,8 @@ spec:
           reloader.stakater.com/auto: "true"
         containers:
           app:
+            tty: true
+            stdin: true
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33


### PR DESCRIPTION
## Changes

- Added `command: ["gateway", "run"]` so Hermes runs in persistent gateway/API server mode instead of interactive CLI (which exited immediately in K8s due to no TTY on stdin)
- Added `API_SERVER_HOST: 0.0.0.0` so the API server binds to all interfaces (required for pod reachability)
- Removed `tty: true` / `stdin: true` (no longer needed for gateway mode)

#8831