### PR TITLE
fix(hermes-agent): use args instead of command to preserve s6 entrypoint

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -41,7 +41,7 @@ spec:
           reloader.stakater.com/auto: "true"
         containers:
           app:
-            command: ["gateway", "run"]
+            args: ["gateway", "run"]
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33


### PR DESCRIPTION
## Changes

- Changed `command` to `args` for the container — the Hermes image uses s6-overlay's `/init` as ENTRYPOINT, which expects `gateway run` as arguments. Using `command` overrode the entrypoint entirely, causing `exec: "gateway": executable file not found in $PATH`.