### PR TITLE
feat(hermes-agent): add container port 8642 and HTTP liveness probe

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -45,6 +45,10 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
+            ports:
+              - name: http
+                containerPort: &port 8642
+                protocol: TCP
             env:
               PORT: "8642"
               API_SERVER_ENABLED: "true"
@@ -55,6 +59,11 @@ spec:
             probes:
               liveness:
                 enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
               readiness:
                 enabled: true
             securityContext:

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -49,6 +49,9 @@ spec:
               - name: http
                 containerPort: &port 8642
                 protocol: TCP
+              - name: dashboard
+                containerPort: 9119
+                protocol: TCP
             env:
               PORT: "8642"
               API_SERVER_ENABLED: "true"
@@ -80,6 +83,8 @@ spec:
         ports:
           http:
             port: 8642
+          dashboard:
+            port: 9119
     persistence:
       data:
         existingClaim: ${APP}-data

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -46,7 +46,7 @@ spec:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
             ports:
-              - name: http
+              - name: gateway
                 containerPort: &port 8642
                 protocol: TCP
               - name: dashboard

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -59,11 +59,6 @@ spec:
             probes:
               liveness:
                 enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /health
-                    port: *port
               readiness:
                 enabled: true
             securityContext:


### PR DESCRIPTION
## Changes

- Added container port declaration for port 8642 (TCP)
- Added HTTP liveness probe against `/health` endpoint
- No closing ref