### PR TITLE
fix(home-automation): envoy responseoverride indent #8945

### DIFF
--- a/kubernetes/main/apps/home-automation/backend-traffic-policy.yaml
+++ b/kubernetes/main/apps/home-automation/backend-traffic-policy.yaml
@@ -21,21 +21,21 @@ spec:
         statusCodes:
           - type: Value
             value: 401
-        source: Local
+      source: Local
 
     # 403 Forbidden
     - match:
         statusCodes:
-          - type: Value:q
+          - type: Value
             value: 403
-        source: Local
+      source: Local
 
     # 404 Not Found
     - match:
         statusCodes:
           - type: Value
             value: 404
-        source: Local
+      source: Local
 
     # 500 Internal Server Error
     - match:


### PR DESCRIPTION
Fixes indentation of `source: Local` in BackendTrafficPolicy (moved from inside `match` to sibling level) and fixes a typo `type: Value:q` → `type: Value`.

Closes #8945