### PR TITLE
fix(home-automation): add response to envoy responseOverride entries #8945

### DIFF
--- a/kubernetes/main/apps/home-automation/backend-traffic-policy.yaml
+++ b/kubernetes/main/apps/home-automation/backend-traffic-policy.yaml
@@ -22,6 +22,7 @@ spec:
           - type: Value
             value: 401
       source: Local
+      response: {}
 
     # 403 Forbidden
     - match:
@@ -29,6 +30,7 @@ spec:
           - type: Value
             value: 403
       source: Local
+      response: {}
 
     # 404 Not Found
     - match:
@@ -36,6 +38,7 @@ spec:
           - type: Value
             value: 404
       source: Local
+      response: {}
 
     # 500 Internal Server Error
     - match:


### PR DESCRIPTION
Each `responseOverride` item requires exactly one of `response` or `redirect`. The 401/403/404 entries were missing `response`, causing the dry-run failure.