### PR TITLE
fix(networking): remove global 4xx error pages #8945

### DIFF
--- a/kubernetes/main/apps/networking/envoy-gateway/config/envoy-proxy.yaml
+++ b/kubernetes/main/apps/networking/envoy-gateway/config/envoy-proxy.yaml
@@ -70,45 +70,6 @@ spec:
 
   # Custom error page redirects - applies to all routes by default
   responseOverride:
-    # 401 Unauthorized
-    - match:
-        statusCodes:
-          - type: Value
-            value: 401
-      redirect:
-        scheme: https
-        hostname: &host error-pages.techtales.io
-        path:
-          type: ReplaceFullPath
-          replaceFullPath: /401.html
-        statusCode: 302
-
-    # 403 Forbidden
-    - match:
-        statusCodes:
-          - type: Value
-            value: 403
-      redirect:
-        scheme: https
-        hostname: *host
-        path:
-          type: ReplaceFullPath
-          replaceFullPath: /403.html
-        statusCode: 302
-
-    # 404 Not Found
-    - match:
-        statusCodes:
-          - type: Value
-            value: 404
-      redirect:
-        scheme: https
-        hostname: *host
-        path:
-          type: ReplaceFullPath
-          replaceFullPath: /404.html
-        statusCode: 302
-
     # 500 Internal Server Error
     - match:
         statusCodes:
@@ -116,7 +77,7 @@ spec:
             value: 500
       redirect:
         scheme: https
-        hostname: *host
+        hostname: &host error-pages.techtales.io
         path:
           type: ReplaceFullPath
           replaceFullPath: /500.html


### PR DESCRIPTION
Remove 401/403/404 redirects from the Gateway-level BackendTrafficPolicy responseOverride. These client error redirects interfere with upstream responses (e.g., Home Assistant returning 401 for unauthenticated API calls).\n\nThe 5xx redirects (500/502/503/504) are kept as those are genuine server errors.