### PR TITLE
ci(linters): exclude superpowers docs from linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ kubernetes/**/bootstrap/**/charts
 # External agent skills (managed via skills-lock.json, install with: npx skills install)
 # To track a self-maintained skill, add: !.agents/skills/<skill-name>
 .agents/skills/
-
-# Superpowers documentation
-docs/superpowers/

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -11,7 +11,7 @@ ENABLE_LINTERS:
   - EDITORCONFIG_EDITORCONFIG_CHECKER
   - REPOSITORY_GITLEAKS
   - SPELL_PROSELINT
-FILTER_REGEX_EXCLUDE: (\.envrc|\.git/*|talos/clusterconfig/*|docs/superpowers/)
+FILTER_REGEX_EXCLUDE: (\.envrc|\.git/.*|talos/clusterconfig/.*|docs/superpowers/.*|\.agents/.*)
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
 YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.*\.sops\..*)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
 fail_fast: false
+exclude: "^(docs/superpowers/.*|\\.agents/.*)$"
 default_stages:
   - pre-commit
   - pre-push


### PR DESCRIPTION
Excludes superpower design specs and plans from Megalinter and pre-commit pipelines.