### PR TITLE
fix(hermes-agent): bypass s6-overlay to run gateway directly avoiding permission errors

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -39,30 +39,10 @@ spec:
         forceRename: *app
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          init-run:
-            image:
-              repository: busybox
-              tag: 1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
-            command:
-              - chown
-              - -R
-              - 1000:1000
-              - /run
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              runAsNonRoot: false
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop:
-                  - ALL
-                add:
-                  - CHOWN
         containers:
           app:
-            args: ["gateway", "run"]
+            command: ["gateway"]
+            args: ["run"]
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.29@sha256:192a40783e9227b5f162b76af4d133050557adebd46e1c9cb40cb79a1317a9f7
@@ -81,7 +61,6 @@ spec:
               HERMES_DASHBOARD: "1"
               HOME: &home /opt/data
               HERMES_HOME: *home
-              S6_READ_ONLY_ROOT: "1"
             envFrom:
               - secretRef:
                   name: ${APP}-secret
@@ -139,8 +118,6 @@ spec:
         type: emptyDir
         advancedMounts:
           hermes:
-            init-run:
-              - path: /run
             app:
               - path: /run
       tmp:


### PR DESCRIPTION
Bypassing the newly introduced s6-overlay (added in image version 2026.5.29) by explicitly overriding the command. This completely avoids all the UID 1000/10000 chown mismatch errors and lets it run securely as UID 1000 just like it did in .28.