### PR TITLE
fix(hermes-agent): add S6_READ_ONLY_ROOT to fix /run permissions

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -50,6 +50,7 @@ spec:
                 containerPort: 9119
                 protocol: TCP
             env:
+              S6_READ_ONLY_ROOT: "1"
               API_SERVER_PORT: "8642"
               API_SERVER_ENABLED: "true"
               API_SERVER_HOST: "0.0.0.0"


### PR DESCRIPTION
The hermes-agent container uses s6-overlay v3 for process supervision. With `readOnlyRootFilesystem: true` and `/run` as an `emptyDir`, s6 creates supervised service directories under `/run/s6-rc/servicedirs/` with permissions that the `hermes` user (uid 10000) can't read.

This caused `main-hermes` and `dashboard` services to fail at startup:
```
s6-svlisten: fatal: unable to s6_svstatus_read: Permission denied
s6-rc: warning: unable to start service main-hermes: command exited 111
```

`S6_READ_ONLY_ROOT=1` tells s6-overlay to properly handle permission setup when rootfs is read-only and `/run` is a writable tmpfs.