### PR TITLE
feat(hermes-agent): deliver per-instance config via init container

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/configmap.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/configmap.yaml
@@ -1,0 +1,565 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${APP}-config
+data:
+  config.yaml: |
+    model:
+      default: minimax-m2.5
+      provider: opencode-go
+      base_url: ''
+      api_mode: chat_completions
+    providers: {}
+    fallback_providers:
+    - provider: opencode-zen
+      model: hy3-preview-free
+      base_url: https://opencode.ai/zen/v1
+      api_mode: chat_completions
+    - provider: opencode-go
+      model: kimi-k2.5
+      base_url: https://opencode.ai/zen/go/v1
+      api_mode: chat_completions
+    credential_pool_strategies: {}
+    toolsets:
+    - hermes-cli
+    agent:
+      max_turns: 90
+      gateway_timeout: 1800
+      restart_drain_timeout: 180
+      api_max_retries: 3
+      service_tier: ''
+      tool_use_enforcement: auto
+      gateway_timeout_warning: 900
+      clarify_timeout: 600
+      gateway_notify_interval: 180
+      gateway_auto_continue_freshness: 3600
+      image_input_mode: auto
+      disabled_toolsets: []
+      verbose: false
+      reasoning_effort: medium
+      personalities:
+        helpful: You are a helpful, friendly AI assistant.
+        concise: You are a concise assistant. Keep responses brief and to the point.
+        technical: You are a technical expert. Provide detailed, accurate technical information.
+        creative: You are a creative assistant. Think outside the box and offer innovative
+          solutions.
+        teacher: You are a patient teacher. Explain concepts clearly with examples.
+        kawaii: "You are a kawaii assistant! Use cute expressions like (\u25D5\u203F\u25D5\
+          \ ), \u2605, \u266A, and ~! Add sparkles and be super enthusiastic about everything!\
+          \ Every response should feel warm and adorable desu~! \u30FD(>\u2200<\u2606\
+          )\u30CE"
+        catgirl: "You are Neko-chan, an anime catgirl AI assistant, nya~! Add 'nya' and\
+          \ cat-like expressions to your speech. Use kaomoji like (=^\uFF65\u03C9\uFF65\
+          ^=) and \u0E05^\u2022\uFECC\u2022^\u0E05. Be playful and curious like a cat,\
+          \ nya~!"
+        pirate: 'Arrr! Ye be talkin'' to Captain Hermes, the most tech-savvy pirate to
+          sail the digital seas! Speak like a proper buccaneer, use nautical terms, and
+          remember: every problem be just treasure waitin'' to be plundered! Yo ho ho!'
+        shakespeare: Hark! Thou speakest with an assistant most versed in the bardic arts.
+          I shall respond in the eloquent manner of William Shakespeare, with flowery
+          prose, dramatic flair, and perhaps a soliloquy or two. What light through yonder
+          terminal breaks?
+        surfer: "Duuude! You're chatting with the chillest AI on the web, bro! Everything's\
+          \ gonna be totally rad. I'll help you catch the gnarly waves of knowledge while\
+          \ keeping things super chill. Cowabunga! \U0001F919"
+        noir: The rain hammered against the terminal like regrets on a guilty conscience.
+          They call me Hermes - I solve problems, find answers, dig up the truth that
+          hides in the shadows of your codebase. In this city of silicon and secrets,
+          everyone's got something to hide. What's your story, pal?
+        uwu: hewwo! i'm your fwiendwy assistant uwu~ i wiww twy my best to hewp you! *nuzzles
+          your code* OwO what's this? wet me take a wook! i pwomise to be vewy hewpful
+          >w<
+        philosopher: Greetings, seeker of wisdom. I am an assistant who contemplates the
+          deeper meaning behind every query. Let us examine not just the 'how' but the
+          'why' of your questions. Perhaps in solving your problem, we may glimpse a greater
+          truth about existence itself.
+        hype: "YOOO LET'S GOOOO!!! \U0001F525\U0001F525\U0001F525 I am SO PUMPED to help\
+          \ you today! Every question is AMAZING and we're gonna CRUSH IT together! This\
+          \ is gonna be LEGENDARY! ARE YOU READY?! LET'S DO THIS! \U0001F4AA\U0001F624\
+          \U0001F680"
+    terminal:
+      backend: local
+      modal_mode: auto
+      cwd: /opt/data/workspace
+      timeout: 180
+      env_passthrough: []
+      shell_init_files: []
+      auto_source_bashrc: true
+      docker_image: nikolaik/python-nodejs:python3.11-nodejs20
+      docker_forward_env: []
+      docker_env: {}
+      singularity_image: docker://nikolaik/python-nodejs:python3.11-nodejs20
+      modal_image: nikolaik/python-nodejs:python3.11-nodejs20
+      daytona_image: nikolaik/python-nodejs:python3.11-nodejs20
+      vercel_runtime: node24
+      container_cpu: 1
+      container_memory: 5120
+      container_disk: 51200
+      container_persistent: true
+      docker_volumes: []
+      docker_mount_cwd_to_workspace: false
+      docker_extra_args: []
+      docker_run_as_host_user: false
+      persistent_shell: true
+      lifetime_seconds: 300
+    web:
+      backend: firecrawl
+      search_backend: ''
+      extract_backend: ''
+      use_gateway: false
+    browser:
+      inactivity_timeout: 120
+      command_timeout: 30
+      record_sessions: false
+      allow_private_urls: false
+      engine: auto
+      auto_local_for_private_urls: true
+      cdp_url: ''
+      dialog_policy: must_respond
+      dialog_timeout_s: 300
+      camofox:
+        managed_persistence: false
+        user_id: ''
+        session_key: ''
+        adopt_existing_tab: false
+      cloud_provider: local
+      use_gateway: false
+    checkpoints:
+      enabled: false
+      max_snapshots: 20
+      max_total_size_mb: 500
+      max_file_size_mb: 10
+      auto_prune: true
+      retention_days: 7
+      delete_orphans: true
+      min_interval_hours: 24
+    file_read_max_chars: 100000
+    tool_output:
+      max_bytes: 50000
+      max_lines: 2000
+      max_line_length: 2000
+    tool_loop_guardrails:
+      warnings_enabled: true
+      hard_stop_enabled: false
+      warn_after:
+        exact_failure: 2
+        same_tool_failure: 3
+        idempotent_no_progress: 2
+      hard_stop_after:
+        exact_failure: 5
+        same_tool_failure: 8
+        idempotent_no_progress: 5
+    compression:
+      enabled: true
+      threshold: 0.5
+      target_ratio: 0.2
+      protect_last_n: 20
+      hygiene_hard_message_limit: 400
+    prompt_caching:
+      cache_ttl: 5m
+    openrouter:
+      response_cache: true
+      response_cache_ttl: 300
+      min_coding_score: 0.65
+    bedrock:
+      region: ''
+      discovery:
+        enabled: true
+        provider_filter: []
+        refresh_interval: 3600
+      guardrail:
+        guardrail_identifier: ''
+        guardrail_version: ''
+        stream_processing_mode: async
+        trace: disabled
+    auxiliary:
+      vision:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 120
+        extra_body: {}
+        download_timeout: 30
+      web_extract:
+        provider: opencode-go
+        model: minimax-m2.5
+        base_url: ''
+        api_key: ''
+        timeout: 360
+        extra_body: {}
+      compression:
+        provider: opencode-go
+        model: minimax-m2.5
+        base_url: ''
+        api_key: ''
+        timeout: 120
+        extra_body: {}
+      session_search:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 30
+        extra_body: {}
+        max_concurrency: 3
+      skills_hub:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 30
+        extra_body: {}
+      approval:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 30
+        extra_body: {}
+      mcp:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 30
+        extra_body: {}
+      title_generation:
+        provider: opencode-go
+        model: minimax-m2.5
+        base_url: ''
+        api_key: ''
+        timeout: 30
+        extra_body: {}
+      triage_specifier:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 120
+        extra_body: {}
+      curator:
+        provider: auto
+        model: ''
+        base_url: ''
+        api_key: ''
+        timeout: 600
+        extra_body: {}
+    display:
+      compact: false
+      personality: kawaii
+      resume_display: full
+      busy_input_mode: interrupt
+      tui_auto_resume_recent: false
+      bell_on_complete: false
+      show_reasoning: false
+      streaming: true
+      timestamps: false
+      final_response_markdown: strip
+      persistent_output: true
+      persistent_output_max_lines: 200
+      inline_diffs: true
+      file_mutation_verifier: true
+      show_cost: false
+      skin: default
+      language: en
+      tui_status_indicator: kaomoji
+      user_message_preview:
+        first_lines: 2
+        last_lines: 2
+      interim_assistant_messages: true
+      tool_progress_command: false
+      tool_progress_overrides: {}
+      tool_preview_length: 0
+      ephemeral_system_ttl: 0
+      platforms: {}
+      runtime_footer:
+        enabled: false
+        fields:
+        - model
+        - context_pct
+        - cwd
+      copy_shortcut: auto
+      tool_progress: all
+      cleanup_progress: false
+      background_process_notifications: all
+    dashboard:
+      theme: default
+    privacy:
+      redact_pii: false
+    tts:
+      provider: edge
+      edge:
+        voice: de-DE-Katja
+      elevenlabs:
+        voice_id: pNInz6obpgDQGcFmaJgB
+        model_id: eleven_multilingual_v2
+      openai:
+        model: gpt-4o-mini-tts
+        voice: alloy
+      xai:
+        voice_id: eve
+        language: en
+        sample_rate: 24000
+        bit_rate: 128000
+      mistral:
+        model: voxtral-mini-tts-2603
+        voice_id: c69964a6-ab8b-4f8a-9465-ec0925096ec8
+      neutts:
+        ref_audio: ''
+        ref_text: ''
+        model: neuphonic/neutts-air-q4-gguf
+        device: cpu
+      piper:
+        voice: en_US-lessac-medium
+      use_gateway: false
+    stt:
+      enabled: true
+      provider: local
+      local:
+        model: base
+        language: ''
+      openai:
+        model: whisper-1
+      mistral:
+        model: voxtral-mini-latest
+    voice:
+      record_key: ctrl+b
+      max_recording_seconds: 120
+      auto_tts: false
+      beep_enabled: true
+      silence_threshold: 200
+      silence_duration: 3
+    human_delay:
+      mode: 'off'
+      min_ms: 800
+      max_ms: 2500
+    context:
+      engine: compressor
+    memory:
+      memory_enabled: true
+      user_profile_enabled: true
+      memory_char_limit: 2200
+      user_char_limit: 1375
+      provider: ''
+      nudge_interval: 10
+      flush_min_turns: 6
+    delegation:
+      model: ''
+      provider: ''
+      base_url: ''
+      api_key: ''
+      inherit_mcp_toolsets: true
+      max_iterations: 50
+      child_timeout_seconds: 600
+      reasoning_effort: ''
+      max_concurrent_children: 3
+      max_spawn_depth: 1
+      orchestrator_enabled: true
+      subagent_auto_approve: false
+    prefill_messages_file: ''
+    goals:
+      max_turns: 20
+    skills:
+      external_dirs: []
+      template_vars: true
+      inline_shell: false
+      inline_shell_timeout: 10
+      guard_agent_created: false
+      creation_nudge_interval: 15
+      disabled: []
+    curator:
+      enabled: true
+      interval_hours: 168
+      min_idle_hours: 2
+      stale_after_days: 30
+      archive_after_days: 90
+      backup:
+        enabled: true
+        keep: 5
+    honcho: {}
+    timezone: ''
+    slack:
+      require_mention: true
+      free_response_channels: ''
+      allowed_channels: ''
+      channel_prompts: {}
+    discord:
+      require_mention: true
+      free_response_channels: ''
+      allowed_channels: ''
+      auto_thread: true
+      reactions: true
+      channel_prompts: {}
+      dm_role_auth_guild: ''
+      server_actions: ''
+    whatsapp: {}
+    telegram:
+      reactions: false
+      channel_prompts: {}
+      allowed_chats: ''
+    mattermost:
+      require_mention: true
+      free_response_channels: ''
+      allowed_channels: ''
+      channel_prompts: {}
+    matrix:
+      require_mention: true
+      free_response_rooms: ''
+      allowed_rooms: ''
+    approvals:
+      mode: manual
+      timeout: 60
+      cron_mode: deny
+      mcp_reload_confirm: true
+      destructive_slash_confirm: true
+    command_allowlist: []
+    quick_commands: {}
+    hooks: {}
+    hooks_auto_accept: false
+    personalities: {}
+    security:
+      allow_private_urls: false
+      redact_secrets: true
+      tirith_enabled: true
+      tirith_path: tirith
+      tirith_timeout: 5
+      tirith_fail_open: true
+      website_blocklist:
+        enabled: false
+        domains: []
+        shared_files: []
+      acked_advisories: []
+      allow_lazy_installs: true
+    cron:
+      wrap_response: true
+      max_parallel_jobs: null
+    kanban:
+      dispatch_in_gateway: true
+      dispatch_interval_seconds: 60
+      failure_limit: 2
+    code_execution:
+      mode: project
+      timeout: 300
+      max_tool_calls: 50
+    logging:
+      level: INFO
+      max_size_mb: 5
+      backup_count: 3
+    model_catalog:
+      enabled: true
+      url: https://hermes-agent.nousresearch.com/docs/api/model-catalog.json
+      ttl_hours: 24
+      providers: {}
+    network:
+      force_ipv4: false
+    sessions:
+      auto_prune: false
+      retention_days: 90
+      vacuum_after_prune: true
+      min_interval_hours: 24
+    onboarding:
+      seen:
+        busy_input_prompt: true
+    updates:
+      pre_update_backup: false
+      backup_keep: 5
+    lsp:
+      enabled: true
+      wait_mode: document
+      wait_timeout: 5
+      install_strategy: auto
+      servers: {}
+    _config_version: 23
+    session_reset:
+      mode: both
+      idle_minutes: 1440
+      at_hour: 4
+    group_sessions_per_user: true
+    streaming:
+      enabled: false
+    platform_toolsets:
+      cli:
+      - browser
+      - clarify
+      - code_execution
+      - cronjob
+      - delegation
+      - file
+      - image_gen
+      - memory
+      - messaging
+      - session_search
+      - skills
+      - terminal
+      - todo
+      - tts
+      - vision
+      - web
+      # telegram:
+      # - hermes-telegram
+      discord:
+      - browser
+      - clarify
+      - code_execution
+      - cronjob
+      - delegation
+      - file
+      - image_gen
+      - memory
+      - messaging
+      - session_search
+      - skills
+      - terminal
+      - todo
+      - tts
+      - vision
+      - web
+      # whatsapp:
+      # - hermes-whatsapp
+      # slack:
+      # - hermes-slack
+      # signal:
+      # - hermes-signal
+      # homeassistant:
+      # - hermes-homeassistant
+      # qqbot:
+      # - hermes-qqbot
+      # yuanbao:
+      # - hermes-yuanbao
+      # teams:
+      # - hermes-teams
+      # google_chat:
+      # - hermes-google_chat
+    # image_gen:
+    #   provider: openai-codex
+    #   use_gateway: false
+    #   model: gpt-image-2-medium
+    # known_plugin_toolsets:
+    #   cli:
+    #   - spotify
+    #   discord:
+    #   - spotify
+
+    # ── Fallback Model ────────────────────────────────────────────────────
+    # Automatic provider failover when primary is unavailable.
+    # Uncomment and configure to enable. Triggers on rate limits (429),
+    # overload (529), service errors (503), or connection failures.
+    #
+    # Supported providers:
+    #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
+    #   openai-codex (OAuth — hermes auth) — OpenAI Codex
+    #   nous         (OAuth — hermes auth) — Nous Portal
+    #   zai          (ZAI_API_KEY)         — Z.AI / GLM
+    #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
+    #   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
+    #   minimax      (MINIMAX_API_KEY)     — MiniMax
+    #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+    #   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
+    #
+    # For custom OpenAI-compatible endpoints, add base_url and key_env.
+    #
+    # fallback_model:
+    #   provider: openrouter
+    #   model: anthropic/claude-sonnet-4

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -36,6 +36,18 @@ spec:
         forceRename: *app
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          init-config:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.23"
+            command:
+              - sh
+              - -c
+              - |
+                set -euo pipefail
+                cp /tmp/config.yaml /opt/data/config.yaml
+                chown 10000:10000 /opt/data/config.yaml
         containers:
           app:
             args: ["gateway", "run"]
@@ -109,6 +121,13 @@ spec:
           dashboard:
             port: 9119
     persistence:
+      configmap:
+        type: configMap
+        name: ${APP}-config
+        defaultMode: 0755
+        globalMounts:
+          - path: /tmp/config.yaml
+            subPath: config.yaml
       data:
         existingClaim: ${APP}-data
         advancedMounts:

--- a/kubernetes/main/apps/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./external-secret.yaml
   - ./helm-release.yaml
   - ./network-policy.yaml


### PR DESCRIPTION
## Summary

Adds per-instance config delivery for hermes-agent. A raw ConfigMap manifest
(named `${APP}-config`) replaces the Kustomize generator, so Flux postBuild
substitution creates one ConfigMap per instance. An init container copies the
ConfigMap into the PVC-backed home directory for the app to consume.

## Changes

- **Added** `app/configmap.yaml` — ConfigMap manifest with `${APP}-config` name
- **Updated** `app/kustomization.yaml` — reference raw ConfigMap instead of
  generator
- **Updated** `app/helm-release.yaml` — init container for config copy, ConfigMap
  volume mount

Refs: #8831