### PR TITLE
fix(atlantis): update gatus healthcheck to expect 405 status code

### DIFF
--- a/kubernetes/components/atlantis/helm-release.yaml
+++ b/kubernetes/components/atlantis/helm-release.yaml
@@ -164,7 +164,7 @@ spec:
             client:
               dns-resolver: tcp://1.1.1.1:53
             conditions:
-              - "[STATUS] == 404"
+              - "[STATUS] == 405"
         hostnames:
           - "{{ .Release.Name }}-webhook.techtales.io"
         parentRefs:


### PR DESCRIPTION
### Description
Updates the Gatus healthcheck for the Atlantis webhook (`/events`) to expect a `405 Method Not Allowed` status code instead of `404`. 

Since the custom error pages were removed, performing a GET request against the webhook endpoint now correctly returns a `405` rather than a `404`. This fixes the failing healthcheck in Gatus.

### Changes
- Modified `helm-release.yaml` in `kubernetes/components/atlantis` to change the `[STATUS] == 404` condition to `[STATUS] == 405`.