### PR TITLE
fix(oauth2-proxy): update gatus healthcheck to expect 403 status code

### DIFF
--- a/kubernetes/main/apps/auth-system/oauth2-proxy/app/helm-release.yaml
+++ b/kubernetes/main/apps/auth-system/oauth2-proxy/app/helm-release.yaml
@@ -131,7 +131,7 @@ spec:
             client:
               dns-resolver: tcp://1.1.1.1:53
             conditions:
-              - "[STATUS] == 404"
+              - "[STATUS] == 403"
         hostnames:
           - auth.techtales.io
         parentRefs:


### PR DESCRIPTION
### Description
Updates the Gatus healthcheck for the oauth2-proxy app to expect a `403 Forbidden` status code instead of `404`. 

Since the custom error pages were removed, the endpoint now correctly returns a `403` rather than a `404`. This fixes the failing healthcheck in Gatus.

### Changes
- Modified `helm-release.yaml` in `kubernetes/main/apps/auth-system/oauth2-proxy/app` to change the `[STATUS] == 404` condition to `[STATUS] == 403`.