### PR TITLE
fix(olla): update gatus healthcheck path and expect 200 status code

### DIFF
--- a/kubernetes/main/apps/ai/olla/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/olla/app/helm-release.yaml
@@ -87,8 +87,9 @@ spec:
         annotations:
           external-dns/unifi: "true"
           gatus.home-operations.com/endpoint: |
+            url: "https://{{ .Release.Name }}.techtales.io/olla/ollama/"
             conditions:
-              - "[STATUS] == 302"
+              - "[STATUS] == 200"
         hostnames:
           - "{{ .Release.Name }}.techtales.io"
         parentRefs:


### PR DESCRIPTION
### Description
Updates the Gatus healthcheck for the olla app. The check now specifically targets the path `/olla/ollama/` and expects a `200 OK` status code rather than a `302`.

### Changes
- Modified `helm-release.yaml` in `kubernetes/main/apps/ai/olla/app` to define the specific URL path in the `gatus.home-operations.com/endpoint` annotation and change the condition to `[STATUS] == 200`.