### PR TITLE
fix(hermes): allow s6 to read svstatus and keep env vars

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -62,6 +62,7 @@ spec:
                 containerPort: 9119
                 protocol: TCP
             env:
+              S6_KEEP_ENV: "1"
               S6_READ_ONLY_ROOT: "1"
               API_SERVER_PORT: "8642"
               API_SERVER_ENABLED: "true"
@@ -105,6 +106,7 @@ spec:
                   - SETUID
                   - SETGID
                   - CHOWN
+                  - DAC_OVERRIDE
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Description

This PR addresses two startup issues with the `hermes-agent` pod running the `s6-overlay`:

1. **Authentication Fix (`HTTP 401: Missing Authentication header`)**: 
   Added `S6_KEEP_ENV: "1"` to the pod environment variables. By default, s6-overlay clears environment variables before passing them to the service. This ensures the OpenRouter/Anthropic API keys are successfully passed down to the application.

2. **s6 Permissions Fix (`s6-svlisten: Permission denied`)**: 
   Added the `DAC_OVERRIDE` capability back to the container. Since the pod uses `fsGroup: 10000`, the `/run` `emptyDir` inherited this group ownership. Because all capabilities were dropped, root lost `DAC_OVERRIDE` (which allows bypassing file permission checks), preventing `s6-svlisten` from accessing its strictly `root:root` owned service directories in `/run/s6-rc`.

**Related Issue:**
Ref: #8831
