### PR TITLE
fix(hermes): mount data volume in init container

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -134,6 +134,8 @@ spec:
           hermes:
             app:
               - path: *home
+            init-config:
+              - path: *home
       run:
         type: emptyDir
         advancedMounts:


### PR DESCRIPTION
## Description

This PR fixes the startup failure in the `hermes-agent` pod caused by the `init-config` container (`cp: can't create '/opt/data/config.yaml': No such file or directory`).

The issue occurred because the persistent data volume (`/opt/data`) was only being mounted to the `app` container, but the `init-config` container also requires it to copy the configuration file into place. I have updated the `advancedMounts` to ensure the `init-config` container mounts the data volume as well.

**Resolves:**
Ref: #8831