### PR TITLE
fix(hermes): pass --insecure to skip dashboard auth gate

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -50,7 +50,7 @@ spec:
                 chown 10000:10000 /opt/data/config.yaml
         containers:
           app:
-            args: ["gateway", "run"]
+            args: ["gateway", "run", "--insecure"]
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.29@sha256:192a40783e9227b5f162b76af4d133050557adebd46e1c9cb40cb79a1317a9f7


### PR DESCRIPTION
## Description

This PR fixes the issue where the dashboard refuses to bind to `0.0.0.0` due to the OAuth auth gate engaging without any auth providers registered.

I have updated the `args` for the `app` container to pass `--insecure`, skipping the auth gate as recommended by the application's error log.

**Resolves:**
Ref: #8831