### PR TITLE
fix(hermes-agent): resolve dashboard command, mounts, and api access

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -25,7 +25,6 @@ spec:
     keepHistory: false
   values:
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
@@ -110,6 +109,7 @@ spec:
                 memory: 1Gi
           dashboard:
             image: *image
+            command: ["hermes"]
             args: ["dashboard", "--host", "0.0.0.0", "--insecure"]
             ports:
               - name: dashboard
@@ -158,6 +158,10 @@ spec:
           hermes:
             app:
               - path: /run
+      run-dashboard:
+        type: emptyDir
+        advancedMounts:
+          hermes:
             dashboard:
               - path: /run
       tmp:
@@ -166,5 +170,9 @@ spec:
           hermes:
             app:
               - path: /tmp
+      tmp-dashboard:
+        type: emptyDir
+        advancedMounts:
+          hermes:
             dashboard:
               - path: /tmp


### PR DESCRIPTION
## Description
This PR resolves several startup and connection issues with the `hermes-agent` dashboard container. 

The dashboard container was previously utilizing the default `s6-overlay` entrypoint which caused it to improperly spin up secondary gateway background services, leading to port collisions and file locking errors. Additionally, it shared `/run` and `/tmp` with the main app container, causing `s6-rc` permission conflicts. Finally, the Kubernetes API connection failed because the service account token was not being mounted.

## Changes Made
- **Fixed Dashboard Command**: Explicitly set the command to `["hermes"]` with args `["dashboard", "--host", "0.0.0.0", "--insecure"]` to bypass the `s6-overlay` `/init` script and prevent background services from colliding.
- **Isolated EmptyDirs**: Added dedicated `run-dashboard` and `tmp-dashboard` emptyDir volumes for the dashboard container to prevent `s6-overlay` race conditions and locking errors with the `app` container.
- **Enabled Service Account Token**: Removed `automountServiceAccountToken: false` from `defaultPodOptions` to ensure the application has the necessary Kubernetes API access (resolving `localhost:8080` connection refused errors).

## Related Issues
- Relates to #8831
