### PR TITLE
ci(task): enforce standard merge commits for pull requests

### DIFF
--- a/.taskfiles/git/Taskfile.yaml
+++ b/.taskfiles/git/Taskfile.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  pr-merge:
+    desc: Merge a pull request safely using a standard merge commit (NEVER SQUASH)
+    summary: |
+      Merges a GitHub pull request using a standard merge commit.
+      Usage: task git:pr-merge -- <PR_NUMBER_OR_URL>
+    cmds:
+      - gh pr merge {{.CLI_ARGS}} --merge --delete-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ After committing and pushing a fix/feature to a branch:
 
 1. Present the commits to the user and ask if they're aligned/happy with the changes.
 2. Ask: "Ready for a PR?" — do not create a PR without confirmation.
+3. **MERGING**: When instructed to merge a PR, YOU MUST ONLY use the `task git:pr-merge -- <PR_NUMBER>` task. NEVER use `gh pr merge --squash`. Squashing is strictly forbidden and breaks repository history.
 
 ### POST-MERGE CLEANUP
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,6 +14,7 @@ includes:
   debug: .taskfiles/debug-tasks/Taskfile.yaml
   devenv: .taskfiles/devenv/Taskfile.yaml
   flux-local: .taskfiles/flux-local/Taskfile.yaml
+  git: .taskfiles/git/Taskfile.yaml
   lint: .taskfiles/lint/Taskfile.yaml
   openbao: .taskfiles/openbao/Taskfile.yaml
   pre-commit: .taskfiles/pre-commit/Taskfile.yaml


### PR DESCRIPTION
## Description
This PR enforces standard merge commits across the repository and strictly forbids squash merging.

- Adds a new `git:pr-merge` task to standardize PR merging using `gh pr merge --merge`.
- Updates `AGENTS.md` instructions to explicitly mandate the use of `task git:pr-merge` and forbid squash commands.
- *Note*: The global `git-commit` skill (`~/.agents/skills/git-commit/SKILL.md`) was also updated directly on the machine to explicitly ban `gh pr merge --squash` across all projects.

## Related Issues
- #8831
