### PR TITLE
ci(task): wait for pipeline success before merging prs

### DIFF
--- a/.taskfiles/git/Taskfile.yaml
+++ b/.taskfiles/git/Taskfile.yaml
@@ -9,4 +9,5 @@ tasks:
       Merges a GitHub pull request using a standard merge commit.
       Usage: task git:pr-merge -- <PR_NUMBER_OR_URL>
     cmds:
+      - gh pr checks {{.CLI_ARGS}} --watch
       - gh pr merge {{.CLI_ARGS}} --merge --delete-branch


### PR DESCRIPTION
## Description
This PR further hardens the `git:pr-merge` task by strictly requiring all CI pipeline checks to pass before the merge is executed.

- Added `gh pr checks {{.CLI_ARGS}} --watch` as a prerequisite command in the Taskfile. 
- This automatically polls and watches the pipeline status. If any check fails, the command exits with a non-zero exit code, aborting the task and preventing the merge.

## Related Issues
- #8831
