### PR TITLE
ci(renovate): add sourceUrl for siderolabs/installer to enable changelogs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,11 @@
       matchUpdateTypes: ["patch", "minor", "major"],
       automerge: false,
     },
+    {
+      description: "add changelog for installer image (source is siderolabs/talos)",
+      matchDepNames: ["ghcr.io/siderolabs/installer"],
+      sourceUrl: "https://github.com/siderolabs/talos",
+    },
     // separate siderolabs per cluster
     {
       matchPackageNames: ["/siderolabs/"],


### PR DESCRIPTION
Adds a `sourceUrl` override for `ghcr.io/siderolabs/installer` pointing to `github.com/siderolabs/talos` so Renovate can fetch release notes/changelogs for this package.

Refs: PR #9115