### PR TITLE
fix: resolve actionlint shellcheck issues in flux-local workflow

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -70,7 +70,7 @@ jobs:
             end
           ')
 
-          echo "clusters=$CLUSTERS" >> $GITHUB_OUTPUT
+          echo "clusters=$CLUSTERS" >> "$GITHUB_OUTPUT"
 
       - name: List Changed Clusters
         run: echo "${{ steps.changed-clusters.outputs.clusters }}"
@@ -168,7 +168,7 @@ jobs:
       - name: List Diff
         run: |
           if [ -f diff.patch ]; then
-            echo "$(cat diff.patch)"
+            cat diff.patch
           else
             echo "Diff file does not exist"
           fi
@@ -177,18 +177,22 @@ jobs:
         id: diff
         run: |
           if [ -f diff.patch ] && [ -s diff.patch ]; then
-            echo 'diff<<EOF' >> $GITHUB_OUTPUT
-            cat diff.patch >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
+            {
+              echo 'diff<<EOF'
+              cat diff.patch
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
           else
-            echo 'diff<<EOF' >> $GITHUB_OUTPUT
-            echo 'no changes found' >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
+            {
+              echo 'diff<<EOF'
+              echo 'no changes found'
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get current time
         id: current-time
-        run: echo "time=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_OUTPUT
+        run: echo "time=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> "$GITHUB_OUTPUT"
 
       # https://github.com/marketplace/actions/sticky-pull-request-comment
       - if: ${{ steps.diff.outputs.diff != '' }}


### PR DESCRIPTION
Fixes 11 pre-existing shellcheck issues in `.github/workflows/flux-local.yaml`:

| Issue | Severity | Fix |
|-------|----------|-----|
| SC2086 (x7) | info | Quote `$GITHUB_OUTPUT` variables |
| SC2129 (x2) | style | Use  block instead of individual redirects |
| SC2005 (x1) | style | Replace `echo "$(cat ...)"` with direct `cat` |
| SC2086 (x1) | info | Quote `$GITHUB_OUTPUT` in date step |

Refs: PR #9041