### PR TITLE
feat: add hermes-webui sidecar to hermes-agent instances #9188

### DIFF
--- a/docs/superpowers/plans/2026-06-14-hermes-webui.md
+++ b/docs/superpowers/plans/2026-06-14-hermes-webui.md
@@ -1,0 +1,252 @@
+# Hermes WebUI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Hermes WebUI as a sidecar container to each existing hermes-agent pod, providing a web-based chat UI with passkey auth for each agent instance.
+
+**Architecture:** A third container (webui) is added to the existing `hermes` controller in `helm-release.yaml`, running `ghcr.io/nesquena/hermes-webui` in gateway mode (`HERMES_WEBUI_CHAT_BACKEND=gateway`) pointing at `localhost:8642`. It reuses the agent's existing PVC and emptyDir volumes. Each instance gets its own HTTPRoute through Envoy Gateway.
+
+**Tech Stack:** bjw-s/app-template (v5.0.1), Flux Kustomization, Envoy Gateway HTTPRoute, External Secrets (OpenBao), NetworkPolicy.
+
+---
+
+### Task 1: Add `HERMES_WEBUI_PASSWORD` to ExternalSecret
+
+**Files:**
+- Modify: `kubernetes/main/apps/hermes-agent/app/external-secret.yaml:18`
+
+- [ ] **Step 1: Add the env mapping**
+
+Add `HERMES_WEBUI_PASSWORD` to the ExternalSecret's template data, so it's available from OpenBao:
+
+```yaml
+        HERMES_WEBUI_PASSWORD: "{{ .HERMES_WEBUI_PASSWORD }}"
+```
+
+Insert it after `OPENCODE_ZEN_API_KEY` on line 25.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+git commit -m "feat(hermes-webui): add HERMES_WEBUI_PASSWORD to external-secret #9188"
+```
+
+---
+
+### Task 2: Add `HOST` postBuild substitution to flux-sync
+
+**Files:**
+- Modify: `kubernetes/main/apps/hermes-agent/flux-sync.yaml:32,65,98,131`
+
+- [ ] **Step 1: Add `HOST` to each instance's postBuild.substitute**
+
+Each of the 4 Kustomization entries in `flux-sync.yaml` needs `HOST` added to `postBuild.substitute`. Match the instance name:
+
+| Instance | Current `APP` value | `HOST` |
+|----------|--------------------|--------|
+| tyriis | `hermes-agent-tyriis` | `euphoria` |
+| jazzlyn | `hermes-agent-jazzlyn` | `moira` |
+| crowlex | `hermes-agent-crowlex` | `titan-ai` |
+| techinik | `hermes-agent-techinik` | `nova` |
+
+For example, the tyriis entry (lines 30-32):
+```yaml
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SUFFIX: data
+      HOST: euphoria
+```
+
+Apply similarly for jazzlyn (`moira`), crowlex (`titan-ai`), techinik (`nova`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/hermes-agent/flux-sync.yaml
+git commit -m "feat(hermes-webui): add HOST postBuild substitution per instance #9188"
+```
+
+---
+
+### Task 3: Add webui container, service port, route and persistence to helm-release
+
+**Files:**
+- Modify: `kubernetes/main/apps/hermes-agent/app/helm-release.yaml`
+
+- [ ] **Step 1: Add the webui container after the dashboard container (line 128)**
+
+Insert the webui container block after the dashboard container's `resources` line (line 128):
+
+```yaml
+          webui:
+            image:
+              repository: ghcr.io/nesquena/hermes-webui
+              tag: 0.51.397@sha256:22af4e3a83f9e98abf46ac325a145fb3bd7d24953bccab30b3ec7928c6c6be4e
+            command: ["python3", "/apptoo/server.py"]
+            ports:
+              - name: webui
+                containerPort: 8787
+                protocol: TCP
+            env:
+              HERMES_WEBUI_HOST: "0.0.0.0"
+              HERMES_WEBUI_PORT: "8787"
+              HERMES_WEBUI_CHAT_BACKEND: "gateway"
+              HERMES_WEBUI_GATEWAY_BASE_URL: "http://localhost:8642"
+              HOME: /opt/data
+              HERMES_WEBUI_STATE_DIR: /opt/data/webui
+            envFrom:
+              - secretRef:
+                  name: ${APP}-secret
+            probes:
+              liveness: &webuiProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *webuiProbes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+```
+
+- [ ] **Step 2: Add webui port to the service (after line 138)**
+
+```yaml
+          webui:
+            port: 8787
+```
+
+- [ ] **Step 3: Add route section (after the service block, line 139)**
+
+```yaml
+    route:
+      webui:
+        annotations:
+          external-dns/cloudflare: "true"
+          external-dns/unifi: "true"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/description: Hermes WebUI Chat
+          gethomepage.dev/group: AI
+          gethomepage.dev/icon: mdi-chat
+          gethomepage.dev/name: Hermes WebUI
+          gatus.home-operations.com/endpoint: |
+            group: external
+        hostnames:
+          - "${HOST}.techtales.io"
+        parentRefs:
+          - name: envoy
+            namespace: networking
+            sectionName: https
+```
+
+- [ ] **Step 4: Add webui persistence mounts (in the persistence section)**
+
+Add webui mounts to existing volumes (data, tmp, run) in the `advancedMounts.hermes` section:
+
+For `data` (existingClaim), add `webui` after `dashboard`:
+```yaml
+            webui:
+              - path: *home
+```
+
+For `run` (emptyDir), add `webui` after `dashboard`:
+```yaml
+            webui:
+              - path: /run
+```
+
+For `tmp` (emptyDir), add `webui` after `dashboard`:
+```yaml
+            webui:
+              - path: /tmp
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+git commit -m "feat(hermes-webui): add webui sidecar container, service port, route and persistence #9188"
+```
+
+---
+
+### Task 4: Update NetworkPolicy for webui port 8787
+
+**Files:**
+- Modify: `kubernetes/main/apps/hermes-agent/app/network-policy.yaml:23-25`
+
+- [ ] **Step 1: Add ingress rule for port 8787 from networking namespace**
+
+Add a second ingress rule after line 25 (after the existing port 8642 rule):
+
+```yaml
+    # Allow incoming traffic from Envoy Gateway for Hermes WebUI
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+      ports:
+        - protocol: TCP
+          port: 8787
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/hermes-agent/app/network-policy.yaml
+git commit -m "feat(hermes-webui): add network policy ingress for webui port 8787 #9188"
+```
+
+---
+
+## Verification
+
+After all tasks are committed and deployed:
+
+```bash
+# Check Flux is happy
+flux get kustomization -n hermes-agent
+
+# Check pods are running with the new webui container
+kubectl get pods -n hermes-agent
+
+# Check the webui container is running inside each pod
+kubectl get pods -n hermes-agent -o jsonpath='{.items[*].spec.containers[*].name}'
+
+# Check HTTPRoutes are created
+kubectl get httproute -n hermes-agent
+
+# Test webui health endpoint
+kubectl port-forward -n hermes-agent pod/hermes-agent-tyriis-xxx 8787:8787
+curl http://localhost:8787/health
+
+# Verify passkey auth works by hitting the webui URL
+curl -I https://euphoria.techtales.io
+```

--- a/docs/superpowers/specs/2026-06-14-hermes-webui-design.md
+++ b/docs/superpowers/specs/2026-06-14-hermes-webui-design.md
@@ -1,0 +1,125 @@
+# Hermes WebUI — Design Doc
+
+## Overview
+
+Add [Hermes WebUI](https://github.com/nesquena/hermes-webui) as a sidecar container to each existing hermes-agent pod, providing a web-based chat UI for each agent instance. Uses gateway-backed chat mode, connecting to the agent's API server on localhost.
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│ hermes-agent-{instance} Pod         │
+│                                     │
+│ ┌──────────┐  ┌───────────┐         │
+│ │ app      │  │ dashboard │         │
+│ │ gateway  │  │ (hermes   │         │
+│ │ run      │  │  dashboard)│        │
+│ │ :8642    │  │ :9119     │         │
+│ └────┬─────┘  └───────────┘         │
+│      │ localhost:8642               │
+│      ▼                              │
+│ ┌──────────┐                        │
+│ │ webui    │                        │
+│ │ server.py│                        │
+│ │ :8787    │                        │
+│ └──────────┘                        │
+│                                     │
+│ PVC: /opt/data (shared)             │
+│ emptyDir: /tmp, /run (shared)       │
+└─────────────────────────────────────┘
+         │
+         │ HTTPRoute
+         ▼
+    Envoy Gateway (euphoria/moira/titan-ai/nova.techtales.io)
+```
+
+## Auth
+
+- Password auth at bootstrap (`HERMES_WEBUI_PASSWORD` from OpenBao secret)
+- WebAuthn passkeys for day-to-day login (registered via Settings → System)
+- No OIDC/OAuth2 needed
+
+## Instances & Hostnames
+
+| Instance | Subdomain |
+|----------|-----------|
+| tyriis | `euphoria.techtales.io` |
+| jazzlyn | `moira.techtales.io` |
+| crowlex | `titan-ai.techtales.io` |
+| techinik | `nova.techtales.io` |
+
+## Container Configuration
+
+Third container in the existing `hermes` controller, alongside `app` and `dashboard`:
+
+| Field | Value |
+|-------|-------|
+| Image | `ghcr.io/nesquena/hermes-webui:0.51.397` |
+| Command | `["python3", "/apptoo/server.py"]` |
+| Port | 8787 (TCP) |
+| SecurityContext | Same as existing containers: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false` |
+
+### Environment
+
+| Variable | Value |
+|----------|-------|
+| `HERMES_WEBUI_HOST` | `0.0.0.0` |
+| `HERMES_WEBUI_PORT` | `8787` |
+| `HERMES_WEBUI_CHAT_BACKEND` | `gateway` |
+| `HERMES_WEBUI_GATEWAY_BASE_URL` | `http://localhost:8642` |
+| `HOME` | `/opt/data` |
+| `HERMES_WEBUI_STATE_DIR` | `/opt/data/webui` |
+| `HERMES_WEBUI_PASSWORD` | From ExternalSecret |
+
+### Persistence
+
+Reuses existing pod volumes — no new volumes needed:
+
+| Volume | Mount Path | Purpose |
+|--------|------------|---------|
+| `data` (PVC) | `/opt/data` | WebUI state, sessions, passkeys |
+| `tmp` (emptyDir) | `/tmp` | Temp files |
+| `run` (emptyDir) | `/run` | Runtime files |
+
+### Probing
+
+Liveness + readiness probe on `GET /health` port 8787, same pattern as existing containers but with the webui's endpoint.
+
+## Service & Route
+
+- A new service port `webui` (8787) added to the existing `service` block
+- A new HTTPRoute per instance, pointing the subdomain to port 8787
+- Annotations for external-dns and homepage
+
+## Network Policy
+
+Add ingress rule for port 8787 from `networking` namespace (Envoy gateway):
+
+```yaml
+ingress:
+  - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: networking
+    ports:
+      - protocol: TCP
+        port: 8787
+```
+
+## Directory Structure
+
+Same multi-instance pattern as the existing agent (`flux-sync.yaml` with 4 Kustomization entries, all pointing to shared `app/` directory):
+
+```
+kubernetes/main/apps/hermes-agent/hermes-webui/
+├── flux-sync.yaml      # 4 Kustomization entries (tyriis, jazzlyn, crowlex, techinik)
+└── app/
+    ├── kustomization.yaml
+    └── helm-release.yaml
+```
+
+Or more likely, since it's a sidecar, the webui config lives directly in the existing `app/` directory as additions to `helm-release.yaml`, and the `flux-sync.yaml` is unchanged (it already deploys the app/ directory which contains all three containers).
+
+## OpenBao Secret
+
+The existing ExternalSecret path `infra/kubernetes/main/hermes-agent/${APP}` already exists for the agent. The webui password (`HERMES_WEBUI_PASSWORD`) will be added to this existing secret entry.

--- a/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
@@ -23,6 +23,7 @@ spec:
         FAL_KEY: "{{ .FAL_KEY }}"
         OPENCODE_GO_API_KEY: "{{ .OPENCODE_GO_API_KEY }}"
         OPENCODE_ZEN_API_KEY: "{{ .OPENCODE_ZEN_API_KEY }}"
+        HERMES_WEBUI_PASSWORD: "{{ .HERMES_WEBUI_PASSWORD }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/hermes-agent/${APP}

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -126,6 +126,60 @@ spec:
                   name: ${APP}-secret
             securityContext: *securityContext
             resources: *resources
+          webui:
+            image:
+              repository: ghcr.io/nesquena/hermes-webui
+              tag: 0.51.397@sha256:22af4e3a83f9e98abf46ac325a145fb3bd7d24953bccab30b3ec7928c6c6be4e
+            command: ["python3", "/apptoo/server.py"]
+            ports:
+              - name: webui
+                containerPort: 8787
+                protocol: TCP
+            env:
+              HERMES_WEBUI_HOST: "0.0.0.0"
+              HERMES_WEBUI_PORT: "8787"
+              HERMES_WEBUI_CHAT_BACKEND: "gateway"
+              HERMES_WEBUI_GATEWAY_BASE_URL: "http://localhost:8642"
+              HOME: *home
+              HERMES_WEBUI_STATE_DIR: /opt/data/webui
+            envFrom:
+              - secretRef:
+                  name: ${APP}-secret
+            probes:
+              liveness: &webuiProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *webuiProbes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8787
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
     service:
       app:
         forceRename: *app
@@ -136,6 +190,26 @@ spec:
             port: 8642
           dashboard:
             port: 9119
+          webui:
+            port: 8787
+    route:
+      webui:
+        annotations:
+          external-dns/cloudflare: "true"
+          external-dns/unifi: "true"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/description: Hermes WebUI Chat
+          gethomepage.dev/group: AI
+          gethomepage.dev/icon: mdi-chat
+          gethomepage.dev/name: Hermes WebUI
+          gatus.home-operations.com/endpoint: |
+            group: external
+        hostnames:
+          - "${HOST}.techtales.io"
+        parentRefs:
+          - name: envoy
+            namespace: networking
+            sectionName: https
     persistence:
       configmap:
         type: configMap
@@ -154,11 +228,15 @@ spec:
               - path: *home
             init-config:
               - path: *home
+            webui:
+              - path: *home
       run:
         type: emptyDir
         advancedMounts:
           hermes:
             app:
+              - path: /run
+            webui:
               - path: /run
       run-dashboard:
         type: emptyDir
@@ -171,6 +249,8 @@ spec:
         advancedMounts:
           hermes:
             app:
+              - path: /tmp
+            webui:
               - path: /tmp
       tmp-dashboard:
         type: emptyDir

--- a/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
@@ -23,6 +23,14 @@ spec:
       ports:
         - protocol: TCP
           port: 8642
+    # Allow incoming traffic from Envoy Gateway for Hermes WebUI
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+      ports:
+        - protocol: TCP
+          port: 8787
   egress:
     # Allow DNS resolution
     - to:

--- a/kubernetes/main/apps/hermes-agent/flux-sync.yaml
+++ b/kubernetes/main/apps/hermes-agent/flux-sync.yaml
@@ -30,6 +30,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_SUFFIX: data
+      HOST: euphoria
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -63,6 +64,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_SUFFIX: data
+      HOST: moira
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -96,6 +98,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_SUFFIX: data
+      HOST: titan-ai
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -129,3 +132,4 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_SUFFIX: data
+      HOST: nova


### PR DESCRIPTION
## Description

Adds [Hermes WebUI](https://github.com/nesquena/hermes-webui) as a sidecar container to each existing hermes-agent pod, providing a web-based chat UI for each agent instance.

### Changes

- **ExternalSecret**: Added `HERMES_WEBUI_PASSWORD` env mapping (from OpenBao) to enable password + passkey auth
- **Flux sync**: Added `HOST` postBuild substitution per instance (euphoria, moira, titan-ai, nova)
- **HelmRelease**: Added webui container (gateway-backed mode, port 8787), service port, HTTPRoute, and persistence mounts
- **NetworkPolicy**: Added ingress rule for port 8787 from Envoy Gateway

### Architecture

Each pod now has three containers: app (gateway), dashboard, and webui. The webui connects to the agent's API via localhost:8642 in gateway-backed mode. Authentication is handled via password + WebAuthn passkeys.

### Subdomains

| Instance | URL |
|----------|-----|
| tyriis | euphoria.techtales.io |
| jazzlyn | moira.techtales.io |
| crowlex | titan-ai.techtales.io |
| techinik | nova.techtales.io |

Closes #9188