### PR TITLE
fix(hermes-webui): skip agent dir discovery and add DAC_OVERRIDE for PVC access #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -140,6 +140,7 @@ spec:
               HERMES_WEBUI_PORT: "8787"
               HERMES_WEBUI_CHAT_BACKEND: "gateway"
               HERMES_WEBUI_GATEWAY_BASE_URL: "http://localhost:8642"
+              HERMES_WEBUI_AGENT_DIR: /nonexistent
               HOME: *home
               HERMES_WEBUI_STATE_DIR: /opt/data/webui
             envFrom:
@@ -174,6 +175,8 @@ spec:
               capabilities:
                 drop:
                   - ALL
+                add:
+                  - DAC_OVERRIDE
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Description

Fixes a PermissionError crash on webui startup. The webui container's `_discover_agent_dir()` scans the PVC for agent source code, which fails because the PVC directories are owned by the agent's UID and the webui container lacks DAC_OVERRIDE.

### Changes
- Added `HERMES_WEBUI_AGENT_DIR=/nonexistent` to skip agent source discovery (not needed in gateway mode)
- Added `DAC_OVERRIDE` capability to allow reading PVC files regardless of ownership

Relates to #9188