### PR TITLE
fix(hermes-webui): install pyyaml deps before starting server #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -130,7 +130,9 @@ spec:
             image:
               repository: ghcr.io/nesquena/hermes-webui
               tag: 0.51.397@sha256:22af4e3a83f9e98abf46ac325a145fb3bd7d24953bccab30b3ec7928c6c6be4e
-            command: ["python3", "/apptoo/server.py"]
+            command: ["/bin/sh", "-c"]
+            args:
+              - uv pip install --system --no-cache -r /apptoo/requirements.txt && python3 /apptoo/server.py
             ports:
               - name: webui
                 containerPort: 8787


### PR DESCRIPTION
## Description

The webui container crashes with `ModuleNotFoundError: No module named 'yaml'` because `pyyaml` and `cryptography` are not pre-installed in the image — they're installed at startup by `docker_init.bash`, which we bypass by running `server.py` directly.

### Changes
- Changed container command to install deps via `uv pip install --system --no-cache -r /apptoo/requirements.txt` before starting the server
- Uses `/bin/sh -c` to chain the commands

Relates to #9188