### PR TITLE
fix(hermes-webui): create venv on PVC to avoid read-only root fs #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -132,7 +132,7 @@ spec:
               tag: 0.51.399@sha256:70b5d946af4bda7676f5ee0707b6727b5c37cb98858d96c766f63588799ec970
             command: ["/bin/sh", "-c"]
             args:
-              - uv pip install --system --no-cache -r /apptoo/requirements.txt && python3 /apptoo/server.py
+              - uv venv /opt/data/webui-venv && uv pip install --no-cache -r /apptoo/requirements.txt && /opt/data/webui-venv/bin/python3 /apptoo/server.py
             ports:
               - name: webui
                 containerPort: 8787


### PR DESCRIPTION
## Description

Replaces `uv pip install --system` with a venv-based approach. The `--system` install fails because `readOnlyRootFilesystem: true` blocks writing to `/usr/local/lib/python3.12/site-packages/`.

### Change
- `uv venv /opt/data/webui-venv` creates a virtual environment on the writable PVC
- `uv pip install` installs deps into the venv
- `/opt/data/webui-venv/bin/python3 /apptoo/server.py` runs from the venv

Relates to #9188