### PR TITLE
fix(hermes-webui): add --clear to uv venv for idempotent restart #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -132,7 +132,7 @@ spec:
               tag: 0.51.399@sha256:70b5d946af4bda7676f5ee0707b6727b5c37cb98858d96c766f63588799ec970
             command: ["/bin/sh", "-c"]
             args:
-              - uv venv /opt/data/webui-venv && uv pip install --no-cache -r /apptoo/requirements.txt && /opt/data/webui-venv/bin/python3 /apptoo/server.py
+              - test -d /opt/data/webui-venv || uv venv /opt/data/webui-venv && /opt/data/webui-venv/bin/pip install --no-cache-dir -r /apptoo/requirements.txt && /opt/data/webui-venv/bin/python3 /apptoo/server.py
             ports:
               - name: webui
                 containerPort: 8787


### PR DESCRIPTION
## Description

`uv venv` fails on pod restart because the venv directory already exists. Adding `--clear` makes it idempotent — re-creates the venv each time the pod starts.

### Change
`uv venv` → `uv venv --clear`

Relates to #9188