### PR TITLE
fix(hermes-webui): use uv pip with --python flag instead of missing pip binary #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -132,7 +132,7 @@ spec:
               tag: 0.51.399@sha256:70b5d946af4bda7676f5ee0707b6727b5c37cb98858d96c766f63588799ec970
             command: ["/bin/sh", "-c"]
             args:
-              - test -d /opt/data/webui-venv || uv venv /opt/data/webui-venv && /opt/data/webui-venv/bin/pip install --no-cache-dir -r /apptoo/requirements.txt && /opt/data/webui-venv/bin/python3 /apptoo/server.py
+              - test -d /opt/data/webui-venv || uv venv /opt/data/webui-venv && uv pip install --python /opt/data/webui-venv/bin/python --no-cache -r /apptoo/requirements.txt && /opt/data/webui-venv/bin/python3 /apptoo/server.py
             ports:
               - name: webui
                 containerPort: 8787


### PR DESCRIPTION
## Description

`uv venv` doesn't install pip by default, so `/opt/data/webui-venv/bin/pip` doesn't exist. Use `uv pip install --python /opt/data/webui-venv/bin/python` instead — this always targets the venv explicitly and works without pip.

### Change
`/opt/data/webui-venv/bin/pip install` → `uv pip install --python /opt/data/webui-venv/bin/python`

Relates to #9188