### PR TITLE
fix(hermes-webui): reorder service ports so webui is primary for route #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -191,16 +191,15 @@ spec:
         primary: true
         controller: hermes
         ports:
+          webui:
+            port: 8787
           api:
             port: 8642
           dashboard:
             port: 9119
-          webui:
-            port: 8787
     route:
       webui:
         annotations:
-          external-dns/cloudflare: "true"
           external-dns/unifi: "true"
           gethomepage.dev/enabled: "true"
           gethomepage.dev/description: Hermes WebUI Chat


### PR DESCRIPTION
## Description

The chart auto-selects the first service port as the HTTPRoute backend. Moving `webui` (8787) to first fixes it routing to port 8642 (agent API).

Also removed `external-dns/cloudflare` annotation.

Relates to #9188