### PR TITLE
fix(hermes-webui): mark webui port as primary for correct HTTPRoute backend #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -191,12 +191,13 @@ spec:
         primary: true
         controller: hermes
         ports:
-          webui:
-            port: 8787
           api:
             port: 8642
           dashboard:
             port: 9119
+          webui:
+            port: 8787
+            primary: true
     route:
       webui:
         annotations:


### PR DESCRIPTION
## Description

The chart selects the primary port alphabetically (defaults to `api`). Added `primary: true` to the `webui` port so the route correctly targets 8787 instead of 8642.

### Change
- Added `primary: true` to the webui service port
- Reverted port order back to original (api, dashboard, webui)

Relates to #9188