### PR TITLE
fix(hermes-webui): point AGENT_DIR to copied source instead of nonexistent #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -153,7 +153,7 @@ spec:
               HERMES_WEBUI_PORT: "8787"
               HERMES_WEBUI_CHAT_BACKEND: "gateway"
               HERMES_WEBUI_GATEWAY_BASE_URL: "http://localhost:8642"
-              HERMES_WEBUI_AGENT_DIR: /nonexistent
+              HERMES_WEBUI_AGENT_DIR: /tmp/agent-src
               HERMES_WEBUI_BOT_NAME: "${AGENT_NAME}"
               HOME: *home
               HERMES_WEBUI_STATE_DIR: /opt/data/webui


### PR DESCRIPTION
## Description

`HERMES_WEBUI_AGENT_DIR` was set to `/nonexistent` to skip discovery, but now the init container copies the agent source to `/tmp/agent-src`. Pointing the env var there so the startup check passes.

### Change
`HERMES_WEBUI_AGENT_DIR: /nonexistent` → `HERMES_WEBUI_AGENT_DIR: /tmp/agent-src`

Relates to #9188