### PR TITLE
fix(hermes-webui): remove HERMES_WEBUI_PASSWORD from secret to enable UI management #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
@@ -23,7 +23,6 @@ spec:
         FAL_KEY: "{{ .FAL_KEY }}"
         OPENCODE_GO_API_KEY: "{{ .OPENCODE_GO_API_KEY }}"
         OPENCODE_ZEN_API_KEY: "{{ .OPENCODE_ZEN_API_KEY }}"
-        HERMES_WEBUI_PASSWORD: "{{ .HERMES_WEBUI_PASSWORD }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/hermes-agent/${APP}


### PR DESCRIPTION
## Description

`HERMES_WEBUI_PASSWORD` env var overrides the UI's built-in password management. Removing it from the ExternalSecret so the password can be managed from Settings → System instead.

**Note:** The webui will be unprotected until a password is set via the UI. Set one immediately after this deploys.

Relates to #9188