### PR TITLE
fix(hermes-webui): re-enable HERMES_WEBUI_PASSWORD and enable passkey feature flag #9188

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
@@ -23,6 +23,7 @@ spec:
         FAL_KEY: "{{ .FAL_KEY }}"
         OPENCODE_GO_API_KEY: "{{ .OPENCODE_GO_API_KEY }}"
         OPENCODE_ZEN_API_KEY: "{{ .OPENCODE_ZEN_API_KEY }}"
+        HERMES_WEBUI_PASSWORD: "{{ .HERMES_WEBUI_PASSWORD }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/hermes-agent/${APP}

--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -155,6 +155,7 @@ spec:
               HERMES_WEBUI_GATEWAY_BASE_URL: "http://localhost:8642"
               HERMES_WEBUI_AGENT_DIR: /tmp/agent-src
               HERMES_WEBUI_BOT_NAME: "${AGENT_NAME}"
+              HERMES_WEBUI_PASSKEY: "1"
               HOME: *home
               HERMES_WEBUI_STATE_DIR: /opt/data/webui
             envFrom:


### PR DESCRIPTION
## Description

Re-adds `HERMES_WEBUI_PASSWORD` to the ExternalSecret and enables passkeys via `HERMES_WEBUI_PASSKEY=1` (disabled by default behind a feature flag).

### Changes
- Re-added `HERMES_WEBUI_PASSWORD` mapping to ExternalSecret
- Added `HERMES_WEBUI_PASSKEY=1` to webui container env

Relates to #9188