### PR TITLE
fix(dragonfly): allow operator health checks in component network policy

### DIFF
--- a/kubernetes/components/dragonfly/network-policy.yaml
+++ b/kubernetes/components/dragonfly/network-policy.yaml
@@ -13,6 +13,16 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: dragonfly-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: dragonfly-operator
+      ports:
+        - port: 9999
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: observability
           podSelector:
             matchLabels:


### PR DESCRIPTION
The dragonfly component's NetworkPolicy only allowed Prometheus on port 9999, but the operator also needs access to perform health checks on Dragonfly pods (e.g. in the media namespace). Added ingress from dragonfly-system namespace for the operator.