### PR TITLE
fix(dragonfly): add control-plane label to operator pod

### DIFF
--- a/kubernetes/main/apps/dragonfly-system/dragonfly/operator/helm-release.yaml
+++ b/kubernetes/main/apps/dragonfly-system/dragonfly/operator/helm-release.yaml
@@ -80,6 +80,8 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
         pod:
+          labels:
+            control-plane: controller-manager
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534


### PR DESCRIPTION
The operator auto-creates a NetworkPolicy per Dragonfly CR that references `control-plane=controller-manager` but the operator pod lacked this label, causing it to block its own health check access on port 9999.