### PR TITLE
fix(firecrawl): comment out keys not present in OpenBao

### DIFF
--- a/kubernetes/main/apps/firecrawl-system/firecrawl/app/external-secret.yaml
+++ b/kubernetes/main/apps/firecrawl-system/firecrawl/app/external-secret.yaml
@@ -16,8 +16,8 @@ spec:
       engineVersion: v2
       data:
         BULL_AUTH_KEY: "{{ .BULL_AUTH_KEY }}"
-        OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
-        SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
+        # OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
+        # SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/firecrawl-system/firecrawl #gitleaks:allow


### PR DESCRIPTION
OPENAI_API_KEY and SLACK_WEBHOOK_URL are not stored in the OpenBao path `infra/kubernetes/main/firecrawl-system/firecrawl`. Comment them out to avoid ExternalSecret sync failures.