### PR TITLE
fix(firecrawl): add FOWNER cap for non-root postgres initdb #8835

### DIFF
--- a/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
@@ -274,6 +274,8 @@ spec:
               runAsGroup: 999
               runAsNonRoot: true
               capabilities:
+                add:
+                  - FOWNER
                 drop:
                   - ALL
             resources:


### PR DESCRIPTION
Adds CAP_FOWNER to postgres container so initdb can chmod the emptyDir volume while still running as non-root.

Refs #8835