### PR TITLE
fix(firecrawl): move NUQ_DATABASE_URL to ExternalSecret template

### DIFF
--- a/kubernetes/main/apps/firecrawl-system/firecrawl/app/external-secret.yaml
+++ b/kubernetes/main/apps/firecrawl-system/firecrawl/app/external-secret.yaml
@@ -16,6 +16,7 @@ spec:
       engineVersion: v2
       data:
         BULL_AUTH_KEY: "{{ .BULL_AUTH_KEY }}"
+        NUQ_DATABASE_URL: "postgresql://{{ .NUQ_DB_USER }}:{{ .NUQ_DB_PASS }}@firecrawl-nuq-postgres.firecrawl-system.svc.cluster.local:5432/postgres"
         # OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
         # SLACK_WEBHOOK_URL: "{{ .SLACK_WEBHOOK_URL }}"
   dataFrom:

--- a/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
@@ -49,7 +49,6 @@ spec:
               LOGGING_LEVEL: INFO
               IS_KUBERNETES: "true"
               HOST: 0.0.0.0
-              NUQ_DATABASE_URL: postgresql://postgres:password@firecrawl-nuq-postgres.firecrawl-system.svc.cluster.local:5432/postgres
             envFrom:
               - secretRef:
                   name: firecrawl-env
@@ -177,7 +176,6 @@ spec:
               LOGGING_LEVEL: INFO
               IS_KUBERNETES: "true"
               HOST: 0.0.0.0
-              NUQ_DATABASE_URL: postgresql://postgres:password@firecrawl-nuq-postgres.firecrawl-system.svc.cluster.local:5432/postgres
             envFrom:
               - secretRef:
                   name: firecrawl-env


### PR DESCRIPTION
Moves the hardcoded NUQ_DATABASE_URL from the HelmRelease into the ExternalSecret template, sourced from NUQ_DB_USER and NUQ_DB_PASS in OpenBao.

Closes #8835