### PR TITLE
feat(konflate): setup in flux-system namespace

### DIFF
--- a/docs/superpowers/plans/2026-06-25-konflate-deployment.md
+++ b/docs/superpowers/plans/2026-06-25-konflate-deployment.md
@@ -1,0 +1,235 @@
+# Konflate Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Konflate to the flux-system namespace for reviewing PRs on github://tyriis/home-ops
+
+**Architecture:** OCIRepository source + HelmRelease with chartRef pattern (same as flux-operator), exposed via HTTPRoute at konflate.techtales.io through the envoy gateway.
+
+**Tech Stack:** Flux CD (OCIRepository, HelmRelease, Kustomization), Helm chart from ghcr.io/home-operations/charts/konflate, Gateway API HTTPRoute
+
+**Issue:** [#9364](https://github.com/tyriis/home-ops/issues/9364)
+**Spec:** `docs/superpowers/specs/2026-06-25-konflate-design.md`
+
+---
+
+## File Structure
+
+### New Files
+- `kubernetes/main/apps/flux-system/konflate/flux-sync.yaml` — Kustomization CRD pointing at `./app/`
+- `kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml` — Lists resources
+- `kubernetes/main/apps/flux-system/konflate/app/oci-repository.yaml` — OCIRepository for the Helm chart
+- `kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml` — HelmRelease with konflate values
+
+### Modified Files
+- `kubernetes/main/apps/flux-system/kustomization.yaml` — Add konflate/flux-sync.yaml to resources
+
+---
+
+### Task 1: Create flux-sync.yaml (Kustomization CRD)
+
+**Files:**
+- Create: `kubernetes/main/apps/flux-system/konflate/flux-sync.yaml`
+
+- [ ] **Step 1: Create Kustomization CRD**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &namespace flux-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: *namespace
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+```
+
+- [ ] **Step 2: Create the directory and write the file**
+
+Run:
+```bash
+mkdir -p kubernetes/main/apps/flux-system/konflate/app
+```
+
+Then write the content above to `kubernetes/main/apps/flux-system/konflate/flux-sync.yaml`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/main/apps/flux-system/konflate/flux-sync.yaml
+git commit -m "feat(konflate): add flux-sync Kustomization CRD #9364"
+```
+
+---
+
+### Task 2: Create OCIRepository for the Helm chart
+
+**Files:**
+- Create: `kubernetes/main/apps/flux-system/konflate/app/oci-repository.yaml`
+
+- [ ] **Step 1: Create OCIRepository**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/home-operations/charts/konflate
+  ref:
+    tag: 0.2.32
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/flux-system/konflate/app/oci-repository.yaml
+git commit -m "feat(konflate): add OCIRepository source for Helm chart #9364"
+```
+
+---
+
+### Task 3: Create HelmRelease with konflate configuration
+
+**Files:**
+- Create: `kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml`
+
+- [ ] **Step 1: Create HelmRelease**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    config:
+      repo: github://tyriis/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.techtales.io
+    secret:
+      existingSecret: konflate-secret
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      parentRefs:
+        - name: envoy
+          namespace: networking
+      hostnames:
+        - konflate.techtales.io
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+```
+
+Note: `secret.existingSecret` references `konflate-secret` which the user will create with the GitHub App credentials, webhook secret, etc.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+git commit -m "feat(konflate): add HelmRelease with config values #9364"
+```
+
+---
+
+### Task 4: Create app kustomization.yaml
+
+**Files:**
+- Create: `kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml`
+
+- [ ] **Step 1: Create kustomization**
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml
+git commit -m "feat(konflate): add app kustomization listing resources #9364"
+```
+
+---
+
+### Task 5: Wire konflate into flux-system kustomization
+
+**Files:**
+- Modify: `kubernetes/main/apps/flux-system/kustomization.yaml`
+
+- [ ] **Step 1: Add konflate to resources**
+
+Current resources:
+```yaml
+resources:
+  - ./namespace.yaml
+  - ./flux-instance/flux-sync.yaml
+  - ./flux-operator/flux-sync.yaml
+```
+
+Add konflate:
+```yaml
+resources:
+  - ./namespace.yaml
+  - ./flux-instance/flux-sync.yaml
+  - ./flux-operator/flux-sync.yaml
+  - ./konflate/flux-sync.yaml
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kubernetes/main/apps/flux-system/kustomization.yaml
+git commit -m "feat(konflate): wire konflate into flux-system kustomization #9364"
+```

--- a/docs/superpowers/specs/2026-06-25-konflate-design.md
+++ b/docs/superpowers/specs/2026-06-25-konflate-design.md
@@ -1,0 +1,88 @@
+# Konflate Deployment Design
+
+**Date:** 2026-06-25
+**Issue:** [#9364](https://github.com/tyriis/home-ops/issues/9364)
+**Scope:** konflate
+
+## Overview
+
+Deploy [Konflate](https://github.com/home-operations/konflate) — a read-only PR review tool for Flux that renders GitOps pull requests as rendered Flux diffs — to the main cluster.
+
+## Architecture
+
+- **Namespace:** `flux-system` (alongside flux-operator and flux-instance)
+- **Chart:** OCI Helm chart from `oci://ghcr.io/home-operations/charts/konflate`
+- **Source:** OCIRepository with `chartRef` pattern (same as flux-operator)
+- **Replicas:** 1 (single-instance, in-memory state; uses `Recreate` strategy)
+
+## Configuration
+
+### Repository
+
+- **Target repo:** `github://tyriis/home-ops` — konflate will review open PRs for this repository
+- **Cluster path:** empty (repo root) — correct for the standard `./kubernetes/...` layout
+
+### Features (First Iteration)
+
+| Feature | Setting | Notes |
+|---------|---------|-------|
+| Status checks | `true` | Post commit status on rendered PRs (needs write token) |
+| PR comments | `true` | Post/update summary comment on PRs (needs write token) |
+| MCP | `false` | Can be enabled in a future iteration |
+| ServiceMonitor | `true` | Prometheus monitoring |
+| Persistence | `false` | State lives in emptyDir; can add PVC later |
+
+### Write-back
+
+Write-back (status checks + PR comments) will use a GitHub App. The secrets will be provided by the user and stored in an existing Secret referenced via `secret.existingSecret`.
+
+### Exposure
+
+- **HTTPRoute:** `konflate.techtales.io`
+- **Gateway:** `envoy` in `networking` namespace
+- **Port:** 8080 (UI/API/websocket)
+- **Annotations:** gatus health check endpoint
+
+### Resource Limits
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| CPU | 50m | (none explicit, burst as needed) |
+| Memory | 256Mi | 1Gi |
+
+Based on kubesearch.dev community patterns and onedr0p/home-ops reference implementation.
+
+## File Changes
+
+### New Files
+
+```
+kubernetes/main/apps/flux-system/konflate/
+├── flux-sync.yaml          # Kustomization CRD pointing at ./app/
+└── app/
+    ├── kustomization.yaml   # Lists resources
+    ├── oci-repository.yaml  # OCIRepository for the Helm chart
+    └── helm-release.yaml    # HelmRelease with konflate values
+```
+
+### Modified Files
+
+```
+kubernetes/main/apps/flux-system/kustomization.yaml  # Add konflate/flux-sync.yaml to resources
+```
+
+## Secrets
+
+The user will provide:
+- GitHub App credentials (`appClientId` + `appPrivateKey`) or a write token
+- Webhook secret
+- Push token (optional, for CI-triggered refreshes)
+
+These will be stored in a pre-existing Secret and referenced via `secret.existingSecret`.
+
+## References
+
+- https://github.com/home-operations/konflate
+- https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/flux-system/konflate
+- https://kubesearch.dev/hr/ghcr.io-home-operations-charts-konflate
+- https://github.com/tyriis/home-ops/issues/9364

--- a/kubernetes/main/apps/flux-system/konflate/app/external-secret.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/external-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &name konflate-secret
+  name: &name konflate-config
 spec:
   refreshInterval: 5m
   secretStoreRef:
@@ -15,8 +15,9 @@ spec:
     template:
       engineVersion: v2
       data:
-        KONFLATE_APP_PRIVATE_KEY: "{{ .KONFLATE_APP_PRIVATE_KEY }}"
         KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/flux-system/konflate

--- a/kubernetes/main/apps/flux-system/konflate/app/external-secret.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name konflate-secret
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: openbao-backend
+    kind: ClusterSecretStore
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        KONFLATE_APP_PRIVATE_KEY: "{{ .KONFLATE_APP_PRIVATE_KEY }}"
+        KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+  dataFrom:
+    - extract:
+        key: infra/kubernetes/main/flux-system/konflate

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    config:
+      repo: github://tyriis/home-ops
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.techtales.io
+    secret:
+      existingSecret: konflate-secret
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      parentRefs:
+        - name: envoy
+          namespace: networking
+      hostnames:
+        - konflate.techtales.io
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -26,7 +26,7 @@ spec:
       prComments: true
       publicUrl: https://konflate.techtales.io
     secret:
-      existingSecret: konflate-secret
+      existingSecret: konflate-config
     httpRoute:
       enabled: true
       annotations:

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -20,7 +20,6 @@ spec:
     keepHistory: false
   values:
     config:
-      appClientId: ""
       repo: github://tyriis/home-ops
       statusChecks: true
       prComments: true

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -29,6 +29,8 @@ spec:
     httpRoute:
       enabled: true
       annotations:
+        external-dns/cloudflare: "true"
+        external-dns/unifi: "true"
         gatus.home-operations.com/endpoint: |
           group: external
       parentRefs:

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -29,11 +29,12 @@ spec:
     httpRoute:
       enabled: true
       annotations:
-        gatus.home-operations.com/endpoint: |-
-          conditions: ["[STATUS] == 200"]
+        gatus.home-operations.com/endpoint: |
+          group: external
       parentRefs:
         - name: envoy
           namespace: networking
+          sectionName: https
       hostnames:
         - konflate.techtales.io
     monitoring:

--- a/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/helm-release.yaml
@@ -20,6 +20,7 @@ spec:
     keepHistory: false
   values:
     config:
+      appClientId: ""
       repo: github://tyriis/home-ops
       statusChecks: true
       prComments: true

--- a/kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./external-secret.yaml
   - ./oci-repository.yaml
   - ./helm-release.yaml

--- a/kubernetes/main/apps/flux-system/konflate/app/oci-repository.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/home-operations/charts/konflate
+  ref:
+    tag: 0.2.32

--- a/kubernetes/main/apps/flux-system/konflate/flux-sync.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/flux-sync.yaml
@@ -20,3 +20,6 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: secops

--- a/kubernetes/main/apps/flux-system/konflate/flux-sync.yaml
+++ b/kubernetes/main/apps/flux-system/konflate/flux-sync.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &namespace flux-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: *namespace
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/main/apps/flux-system/kustomization.yaml
+++ b/kubernetes/main/apps/flux-system/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./namespace.yaml
   - ./flux-instance/flux-sync.yaml
   - ./flux-operator/flux-sync.yaml
+  - ./konflate/flux-sync.yaml

--- a/kubernetes/main/apps/networking/cloudflared/app/resources/config.yaml
+++ b/kubernetes/main/apps/networking/cloudflared/app/resources/config.yaml
@@ -49,6 +49,8 @@ ingress:
     service: https://kromgo.techtales.io
   - hostname: n8n-webhook.techtales.io
     service: https://n8n-webhook.techtales.io
+  - hostname: konflate.techtales.io
+    service: https://konflate.techtales.io
   - hostname: status.techtales.io
     service: https://status.techtales.io
 


### PR DESCRIPTION
Deploy [Konflate](https://github.com/home-operations/konflate) — a read-only PR review tool for Flux that renders GitOps pull requests as rendered Flux diffs.

**Changes:**
- Add OCIRepository source for the Helm chart at `oci://ghcr.io/home-operations/charts/konflate:0.2.32`
- Add HelmRelease with config: repo `github://tyriis/home-ops`, status checks, PR comments, HTTPRoute at `konflate.techtales.io`
- Wire into flux-system kustomization

**Requires before sync:**
- Create `konflate-secret` Secret in `flux-system` namespace with GitHub App credentials

Ref: #9364