### PR TITLE
chore(mise): switch to explicit aqua backends, link mise-versions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,36 +1,37 @@
 [tools]
-vcluster = "0.35.1"
-# https://age-encryption.org/
-age = "1.3.1"
-# https://direnv.net/
-direnv = "2.37.1"
-# https://fluxcd.io/
-flux2 = "2.8.8"
-# https://gitleaks.io/
-gitleaks = "8.30.1"
-# https://helm.sh/
-helm = "4.2.0"
-# https://k9scli.io/
-k9s = "0.51.0"
-# https://kubernetes.io/docs/reference/kubectl/
-kubectl = "1.36.2"
-# https://kustomize.io/
-kustomize = "5.8.1"
-# https://nodejs.org/
+# https://mise-versions.jdx.dev/tools/vcluster
+"aqua:loft-sh/vcluster" = "0.35.1"
+# https://mise-versions.jdx.dev/tools/age
+"aqua:FiloSottile/age" = "1.3.1"
+# https://mise-versions.jdx.dev/tools/direnv
+"aqua:direnv/direnv" = "2.37.1"
+# https://mise-versions.jdx.dev/tools/flux2
+"aqua:fluxcd/flux2" = "2.8.8"
+# https://mise-versions.jdx.dev/tools/gitleaks
+"aqua:gitleaks/gitleaks" = "8.30.1"
+# https://mise-versions.jdx.dev/tools/helm
+"aqua:helm/helm" = "4.2.0"
+# https://mise-versions.jdx.dev/tools/k9s
+"aqua:derailed/k9s" = "0.51.0"
+# https://mise-versions.jdx.dev/tools/kubectl
+"aqua:kubernetes/kubernetes/kubectl" = "1.36.2"
+# https://mise-versions.jdx.dev/tools/kustomize
+"aqua:kubernetes-sigs/kustomize" = "5.8.1"
+# https://mise-versions.jdx.dev/tools/node
 # node = "24.14.0"
-# https://pre-commit.com/
-pre-commit = "4.6.0"
-# https://github.com/mozilla/sops
-sops = "3.13.1"
-# https://github.com/budimanjojo/talhelper
-talhelper = "3.1.12"
-# https://www.talos.dev/
-talosctl = "1.13.5"
-# https://taskfile.dev/
-task = "3.51.1"
-# https://trivy.dev/
-trivy = "0.71.2"
-# minio client
+# https://mise-versions.jdx.dev/tools/pre-commit
+"aqua:pre-commit/pre-commit" = "4.6.0"
+# https://mise-versions.jdx.dev/tools/sops
+"aqua:getsops/sops" = "3.13.1"
+# https://mise-versions.jdx.dev/tools/talhelper
+"aqua:budimanjojo/talhelper" = "3.1.12"
+# https://mise-versions.jdx.dev/tools/talosctl
+"aqua:siderolabs/talos" = "1.13.5"
+# https://mise-versions.jdx.dev/tools/task
+"aqua:go-task/task" = "3.51.1"
+# https://mise-versions.jdx.dev/tools/trivy
+"aqua:aquasecurity/trivy" = "0.71.2"
+# https://mise-versions.jdx.dev/tools/mc
 "aqua:minio/mc" = "RELEASE.2025-08-13T08-35-41Z"
-# https://openbao.org/
+# https://mise-versions.jdx.dev/tools/openbao
 "aqua:openbao/openbao/bao" = "2.5.5"

--- a/.mise.toml
+++ b/.mise.toml
@@ -33,4 +33,4 @@ trivy = "0.71.2"
 # minio client
 "aqua:minio/mc" = "RELEASE.2025-08-13T08-35-41Z"
 # https://openbao.org/
-openbao = "2.5.5"
+"aqua:openbao/openbao/bao" = "2.5.5"

--- a/kubernetes/utility/bootstrap/.mise.toml
+++ b/kubernetes/utility/bootstrap/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
-# https://helm.sh/
-helm = "3.21.2"
+# https://mise-versions.jdx.dev/tools/helm
+"aqua:helm/helm" = "3.21.2"


### PR DESCRIPTION
Updates all `.mise.toml` files to use explicit `aqua:` backend prefix and link to `https://mise-versions.jdx.dev/tools/<tool>` instead of tool homepages.