### PR TITLE
fix(talos): rename zone label from home-lab to home on talos01 and talos02

### DIFF
--- a/talos/main/talconfig.yaml
+++ b/talos/main/talconfig.yaml
@@ -92,7 +92,7 @@ nodes:
           - network: 169.254.255.103/32
             metric: 2048
     nodeLabels:
-      topology.kubernetes.io/zone: home-lab
+      topology.kubernetes.io/zone: home
     nodeAnnotations:
       tuppr.home-operations.com/factory-url: "factory.talos.dev/metal-installer-secureboot"
 
@@ -172,7 +172,7 @@ nodes:
           - network: 169.254.255.103/32
             metric: 2048
     nodeLabels:
-      topology.kubernetes.io/zone: home-lab
+      topology.kubernetes.io/zone: home
     nodeAnnotations:
       tuppr.home-operations.com/factory-url: "factory.talos.dev/metal-installer-secureboot"
 


### PR DESCRIPTION
## Changes

- **Zone label**: Changed talos01/talos02 `topology.kubernetes.io/zone` from `home-lab` → `home` for consistency with talos03

## Related

- Fixes documented in `rack-plan-42u.md`