### PR TITLE
fix(ml-detector): add MPLCONFIGDIR env and writable /mpl mount

### DIFF
--- a/kubernetes/main/apps/jazzlyn/ml-detector/app/helm-release.yaml
+++ b/kubernetes/main/apps/jazzlyn/ml-detector/app/helm-release.yaml
@@ -48,6 +48,7 @@ spec:
           app:
             env:
               CONFIG_PATH: /config/configuration.yaml
+              MPLCONFIGDIR: /mpl
               TORCH_HOME: /torch
               TORCHINDUCTOR_CACHE_DIR: /torch
               YOLO_CACHE_DIR: /yolo
@@ -128,6 +129,9 @@ spec:
             app:
               - path: /models
                 subPath: models
+                readOnly: false
+              - path: /mpl
+                subPath: mpl
                 readOnly: false
               - path: /torch
                 subPath: torch


### PR DESCRIPTION
ml-detector fails to start with `OSError: Matplotlib requires access to a writable cache directory`. The pod runs with `readOnlyRootFilesystem: true` and had no writable path for Matplotlib's config cache.

Adds `MPLCONFIGDIR=/mpl` env var and a corresponding `emptyDir` subPath mount, following the same pattern as `/torch` and `/yolo`.