### PR TITLE
revert(immich): remove oauth env vars - immich uses admin ui not env vars

### DIFF
--- a/kubernetes/main/apps/media/immich/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/immich/app/helm-release.yaml
@@ -45,15 +45,6 @@ spec:
               IMMICH_MACHINE_LEARNING_ENABLED: "true"
               IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning.media.svc.cluster.local:3003 #NOSONAR allow http
               IMMICH_SERVER_URL: https://immich.techtales.io
-              IMMICH_OAUTH_AUTO_LAUNCH: "true"
-              IMMICH_OAUTH_AUTO_REGISTER: "true"
-              IMMICH_OAUTH_BUTTON_TEXT: "Login with Pocket ID"
-              IMMICH_OAUTH_ENABLED: "true"
-              IMMICH_OAUTH_ISSUER_URL: https://id.techtales.io/.well-known/openid-configuration
-              IMMICH_OAUTH_SCOPE: "openid email profile groups"
-              IMMICH_OAUTH_STORAGE_LABEL_CLAIM: preferred_username
-              IMMICH_OAUTH_END_SESSION_ENDPOINT: https://id.techtales.io/api/oidc/end-session
-              IMMICH_OAUTH_MOBILE_REDIRECT_URI: https://immich.techtales.io/api/oauth/mobile-redirect
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/main/apps/media/immich/database/external-secret.yaml
+++ b/kubernetes/main/apps/media/immich/database/external-secret.yaml
@@ -73,8 +73,6 @@ spec:
         DB_DATABASE_NAME: "{{ .DB_USERNAME }}"
         DB_USERNAME: "{{ .DB_USERNAME }}"
         DB_PASSWORD: "{{ .DB_PASSWORD }}"
-        IMMICH_OAUTH_CLIENT_ID: "{{ .OAUTH_CLIENT_ID }}"
-        IMMICH_OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/media/immich


### PR DESCRIPTION
Cleaned up — OAuth env vars removed. Immich v3.x doesn't support `IMMICH_OAUTH_*` env vars. OAuth must be configured manually via the Admin UI (`Administration → Settings → OAuth`).