### PR TITLE
ci(renovate): ignore bootstrap .mise.toml from updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,5 +76,10 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
     },
+    {
+      description: "Pin bootstrap .mise.toml - Helm 3.x required for bootstrap compatibility",
+      matchFileNames: ["kubernetes/utility/bootstrap/.mise.toml"],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Adds a new Renovate `packageRule` to `.github/renovate.json5` that disables updates for `kubernetes/utility/bootstrap/.mise.toml`.
- The bootstrap process renders Helm charts via `kubectl kustomize --enable-helm` before Flux takes over, and depends on Helm 3.x. Upgrading that file's pinned Helm to v4 breaks the bootstrap, so the rule pins it at its current version.
- All other `.mise.toml` files in the repo continue to receive Renovate updates as normal.