### PR TITLE
refactor(app-template): reconfigure SA to v5 defaults

### DIFF
--- a/devenv/oci/apps/kube-tools/i-see-dead-pods/app/helm-release.yaml
+++ b/devenv/oci/apps/kube-tools/i-see-dead-pods/app/helm-release.yaml
@@ -26,6 +26,8 @@ spec:
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   # https://github.com/tyriis/i-see-dead-pods
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     serviceAccount:
       i-see-dead-pods: {}
     controllers:

--- a/kubernetes/components/minecraft/helm-release.yaml
+++ b/kubernetes/components/minecraft/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://bjw-s-labs.github.io/helm-charts/docs/app-template/
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/ai/llm-guard/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/llm-guard/app/helm-release.yaml
@@ -24,11 +24,8 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/ai/olla/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/olla/app/helm-release.yaml
@@ -24,11 +24,8 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/ai/ollama/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/ollama/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       main:

--- a/kubernetes/main/apps/ai/open-webui/app/helm-release.yaml
+++ b/kubernetes/main/apps/ai/open-webui/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       main:

--- a/kubernetes/main/apps/anubis-system/anubis-grafana/app/helm-release.yaml
+++ b/kubernetes/main/apps/anubis-system/anubis-grafana/app/helm-release.yaml
@@ -26,11 +26,8 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/backstage/backstage/app/helm-release.yaml
+++ b/kubernetes/main/apps/backstage/backstage/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
     controllers:
       backstage:

--- a/kubernetes/main/apps/default/echo-server/app/helm-release.yaml
+++ b/kubernetes/main/apps/default/echo-server/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       echo:

--- a/kubernetes/main/apps/default/it-tools/app/helm-release.yaml
+++ b/kubernetes/main/apps/default/it-tools/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     defaultPodOptions:
       securityContext:

--- a/kubernetes/main/apps/default/openspeedtest/app/helm-release.yaml
+++ b/kubernetes/main/apps/default/openspeedtest/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       openspeedtest:

--- a/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
+++ b/kubernetes/main/apps/firecrawl-system/firecrawl/app/helm-release.yaml
@@ -24,9 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
-
     controllers:
       api:
         replicas: 1

--- a/kubernetes/main/apps/flux-system/flux-instance/webhook/helm-release.yaml
+++ b/kubernetes/main/apps/flux-system/flux-instance/webhook/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     rawResources:
       flux-system:

--- a/kubernetes/main/apps/gaming/minecraft-java/private-fabric-world/helm-release.yaml
+++ b/kubernetes/main/apps/gaming/minecraft-java/private-fabric-world/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/gaming/minecraft-java/private-velocity-proxy/helm-release.yaml
+++ b/kubernetes/main/apps/gaming/minecraft-java/private-velocity-proxy/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/gaming/minecraft-java/public-fabric-world/helm-release.yaml
+++ b/kubernetes/main/apps/gaming/minecraft-java/public-fabric-world/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/gaming/minecraft-java/public-forge-world/helm-release.yaml
+++ b/kubernetes/main/apps/gaming/minecraft-java/public-forge-world/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/gaming/minecraft-java/public-velocity-proxy/helm-release.yaml
+++ b/kubernetes/main/apps/gaming/minecraft-java/public-velocity-proxy/helm-release.yaml
@@ -27,10 +27,7 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/home-automation/esphome/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/esphome/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       esphome:
         annotations:

--- a/kubernetes/main/apps/home-automation/govee2mqtt/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/govee2mqtt/app/helm-release.yaml
@@ -25,8 +25,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       govee2mqtt:
         annotations:

--- a/kubernetes/main/apps/home-automation/home-assistant/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/home-assistant/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       home-assistant:
         annotations:

--- a/kubernetes/main/apps/home-automation/locking-service/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/locking-service/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       locking-service:
         replicas: 3

--- a/kubernetes/main/apps/home-automation/matter-server/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/matter-server/app/helm-release.yaml
@@ -25,8 +25,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       main:
         annotations:

--- a/kubernetes/main/apps/home-automation/n8n/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/n8n/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       n8n:
         annotations:

--- a/kubernetes/main/apps/home-automation/node-red/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/node-red/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       node-red:
         strategy: Recreate

--- a/kubernetes/main/apps/home-automation/ring-mqtt/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/ring-mqtt/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       ring-mqtt:
         annotations:

--- a/kubernetes/main/apps/home-automation/zigbee2mqtt/app/helm-release.yaml
+++ b/kubernetes/main/apps/home-automation/zigbee2mqtt/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       zigbee2mqtt:
         pod:

--- a/kubernetes/main/apps/jazzlyn/ml-detector/app/helm-release.yaml
+++ b/kubernetes/main/apps/jazzlyn/ml-detector/app/helm-release.yaml
@@ -24,12 +24,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     # https://github.com/jazzlyn/ml-detector
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/kube-tools/i-see-dead-pods/app/helm-release.yaml
+++ b/kubernetes/main/apps/kube-tools/i-see-dead-pods/app/helm-release.yaml
@@ -25,6 +25,8 @@ spec:
     keepHistory: false
   values:
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
+    defaultPodOptions:
+      automountServiceAccountToken: true
     serviceAccount:
       i-see-dead-pods: {}
     controllers:

--- a/kubernetes/main/apps/kube-tools/irqbalance/app/helm-release.yaml
+++ b/kubernetes/main/apps/kube-tools/irqbalance/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       irqbalance:

--- a/kubernetes/main/apps/media/bazarr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       bazarr:

--- a/kubernetes/main/apps/media/filebrowser/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/filebrowser/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://filebrowserquantum.com/en/docs/
     controllers:
       *app :

--- a/kubernetes/main/apps/media/immich/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/immich/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       server:
         annotations:

--- a/kubernetes/main/apps/media/jellyfin/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/jellyfin/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     # https://github.com/jellyfin/jellyfin
     controllers:

--- a/kubernetes/main/apps/media/nzbget/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/nzbget/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     # https://github.com/nzbgetcom/nzbget
     controllers:

--- a/kubernetes/main/apps/media/plex/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/plex/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       plex:

--- a/kubernetes/main/apps/media/prowlarr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/prowlarr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       prowlarr:

--- a/kubernetes/main/apps/media/radarr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/radarr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       radarr:

--- a/kubernetes/main/apps/media/recyclarr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/recyclarr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       recyclarr:

--- a/kubernetes/main/apps/media/sabnzbd/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/sabnzbd/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       sabnzbd:

--- a/kubernetes/main/apps/media/seerr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/seerr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       seerr:

--- a/kubernetes/main/apps/media/sonarr/app/helm-release.yaml
+++ b/kubernetes/main/apps/media/sonarr/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       sonarr:

--- a/kubernetes/main/apps/networking/cloudflared/app/helm-release.yaml
+++ b/kubernetes/main/apps/networking/cloudflared/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       cloudflared:

--- a/kubernetes/main/apps/networking/error-pages/app/helm-release.yaml
+++ b/kubernetes/main/apps/networking/error-pages/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       *app :
         replicas: 2

--- a/kubernetes/main/apps/notification/apprise/app/helm-release.yaml
+++ b/kubernetes/main/apps/notification/apprise/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       main:
         annotations:

--- a/kubernetes/main/apps/observability/kromgo/app/helm-release.yaml
+++ b/kubernetes/main/apps/observability/kromgo/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       kromgo:

--- a/kubernetes/main/apps/observability/speedtest-exporter/app/helm-release.yaml
+++ b/kubernetes/main/apps/observability/speedtest-exporter/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       speedtest-exporter:
         annotations:

--- a/kubernetes/main/apps/observability/unpoller/app/helm-release.yaml
+++ b/kubernetes/main/apps/observability/unpoller/app/helm-release.yaml
@@ -24,10 +24,7 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568

--- a/kubernetes/main/apps/productivity/karakeep/app/helm-release.yaml
+++ b/kubernetes/main/apps/productivity/karakeep/app/helm-release.yaml
@@ -25,8 +25,6 @@ spec:
     keepHistory: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
       securityContext:
         fsGroup: 1000

--- a/kubernetes/main/apps/productivity/scanservjs/app/helm-release.yaml
+++ b/kubernetes/main/apps/productivity/scanservjs/app/helm-release.yaml
@@ -25,8 +25,6 @@ spec:
     keepHistory: false
   # https://github.com/sbs20/scanservjs
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       scanservjs:
         annotations:

--- a/kubernetes/main/apps/productivity/syncthing/app/helm-release.yaml
+++ b/kubernetes/main/apps/productivity/syncthing/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/main/apps/tekton-system/tekton/krr-cron/helm-release.yaml
+++ b/kubernetes/main/apps/tekton-system/tekton/krr-cron/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       krr:

--- a/kubernetes/main/apps/voice-assistant/piper/app/helm-release.yaml
+++ b/kubernetes/main/apps/voice-assistant/piper/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       piper:

--- a/kubernetes/main/apps/voice-assistant/whisper/app/helm-release.yaml
+++ b/kubernetes/main/apps/voice-assistant/whisper/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       whisper:

--- a/kubernetes/utility/apps/default/echo-server/app/helm-release.yaml
+++ b/kubernetes/utility/apps/default/echo-server/app/helm-release.yaml
@@ -26,8 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       echo:

--- a/kubernetes/utility/apps/secops/openbao/snapshots/helm-release.yaml
+++ b/kubernetes/utility/apps/secops/openbao/snapshots/helm-release.yaml
@@ -27,8 +27,6 @@ spec:
     keepHistory: false
   # https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/values.yaml
   values:
-    global:
-      createDefaultServiceAccount: false
     controllers:
       openbao-snapshots:
         type: cronjob

--- a/kubernetes/utility/apps/secops/pocket-id/app/helm-release.yaml
+++ b/kubernetes/utility/apps/secops/pocket-id/app/helm-release.yaml
@@ -24,8 +24,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    global:
-      createDefaultServiceAccount: false
     # https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
     controllers:
       pocket-id:


### PR DESCRIPTION
## Changes

Aligns all app-template HelmReleases with app-template v5's new default SA approach:

- **Remove `global.createDefaultServiceAccount: false`** (54 files) — v5 auto-creates a dedicated SA per release, so suppressing it is no longer needed
- **Remove redundant `automountServiceAccountToken: false`** (11 files) — v5 already defaults to `false`
- **Add `automountServiceAccountToken: true`** for `i-see-dead-pods` (2 files) — this app uses `kubectl` with RBAC but was missing the explicit opt-in
- **Preserve existing `automountServiceAccountToken: true`** on 5 apps that need K8s API access (gatus, homepage, dragonfly-operator, barman-cloud, atlantis)

Closes #9777