### PR TITLE
feat(hermes-agent): add HERMES_WRITE_SAFE_ROOT env var

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -79,6 +79,7 @@ spec:
               # API_SERVER_MODEL_NAME: "${APP}"
               HOME: &home /opt/data
               HERMES_HOME: *home
+              HERMES_WRITE_SAFE_ROOT: /opt/data
               WIKI_PATH: /opt/data/wiki
               FIRECRAWL_API_URL: http://firecrawl-api.firecrawl-system.svc.cluster.local:3002 #NOSONAR allow http
             envFrom:


### PR DESCRIPTION
Closes #9590

Configures `HERMES_WRITE_SAFE_ROOT=/opt/data` to sandbox the agent's file writes to the persistent data directory, preventing writes to ephemeral mounts like `/tmp` and `/run`.

See NousResearch/hermes-agent#64347 for context on the flag.