### PR TITLE
feat(hermes-agent): disable lazy installs

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/helm-release.yaml
@@ -79,6 +79,7 @@ spec:
               # API_SERVER_MODEL_NAME: "${APP}"
               HOME: &home /opt/data
               HERMES_HOME: *home
+              HERMES_DISABLE_LAZY_INSTALLS: "true"
               HERMES_WRITE_SAFE_ROOT: /opt/data
               WIKI_PATH: /opt/data/wiki
               FIRECRAWL_API_URL: http://firecrawl-api.firecrawl-system.svc.cluster.local:3002 #NOSONAR allow http


### PR DESCRIPTION
Refs #9590

Sets `HERMES_DISABLE_LAZY_INSTALLS=true` on the app container.

With `S6_READ_ONLY_ROOT=1`, `readOnlyRootFilesystem: true`, and the custom image dropping root privileges after S6 init, lazy installs fail because the agent can't write to system paths. This env var tells the agent not to attempt them.