### PR TITLE
fix(karakeep): update meilisearch arg to --upgrade-db for v1.51.0

### DIFF
--- a/kubernetes/main/apps/productivity/karakeep/app/helm-release.yaml
+++ b/kubernetes/main/apps/productivity/karakeep/app/helm-release.yaml
@@ -128,7 +128,7 @@ spec:
               tag: v1.51.0@sha256:a9eb29ee09ab4943db3b4c68620bd6f3382e6b2b0ac4431c0e607b48dbcd4c14
             args:
               - /bin/meilisearch
-              - --experimental-dumpless-upgrade
+              - --upgrade-db
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
Renovate PR #9768 bumped meilisearch from v1.50.0 to v1.51.0. The v1.51.0 release [stabilized the dumpless upgrade feature](https://github.com/meilisearch/meilisearch/releases/tag/v1.51.0), renaming `--experimental-dumpless-upgrade` to `--upgrade-db`.

The old flag causes the meilisearch container to fail on startup with:
```
unexpected argument '--experimental-dumpless-upgrade' found
tip: a similar argument exists: '--experimental-logs-mode'
```