### PR TITLE
feat(unsloth): add unsloth workload for red via doco-cd

### DIFF
--- a/docker/.doco-cd.red.yaml
+++ b/docker/.doco-cd.red.yaml
@@ -18,3 +18,8 @@ working_dir: docker/deploy/node-exporter
 ---
 name: comfyui
 working_dir: docker/deploy/comfyui
+---
+name: unsloth
+working_dir: docker/red/unsloth
+env_files:
+  - .env

--- a/docker/deploy/unsloth/README.md
+++ b/docker/deploy/unsloth/README.md
@@ -1,0 +1,40 @@
+# unsloth
+
+Unsloth — LLM fine-tuning toolkit with Unsloth Studio (web UI + OpenAI/Anthropic-compatible API) and Jupyter Lab, running on the NVIDIA GPU of the target host.
+
+## Layout
+
+- `compose.yaml`: shared compose definition (uses `SOPS_ENV_FILE`, default `sops.env`)
+- `docker/red/unsloth/compose.yaml`: red target instance
+- `docker/red/unsloth/sops.env`: red encrypted dotenv (JUPYTER_PASSWORD, USER_PASSWORD, UNSLOTH_STUDIO_PASSWORD)
+- `docker/red/unsloth/.env`: target identifier
+
+## Ports
+
+- `8000`: Unsloth Studio UI + API — bound on all interfaces (LAN).
+- `8888`: Jupyter Lab — bound to `127.0.0.1` only.
+
+## Secrets
+
+Passwords are stored in the target's SOPS-encrypted `sops.env`:
+
+- `JUPYTER_PASSWORD` — Jupyter Lab login.
+- `USER_PASSWORD` — sudo inside the container.
+- `UNSLOTH_STUDIO_PASSWORD` — Studio admin password (avoids interactive first-run bootstrap).
+
+## Manual decrypt check
+
+```bash
+sops --decrypt docker/red/unsloth/sops.env
+```
+
+## Runtime requirement on doco-cd host
+
+- `doco-cd` must have a valid age private key configured via `SOPS_AGE_KEY_FILE` (or `SOPS_AGE_KEY`).
+- NVIDIA driver + nvidia-container-toolkit must be installed; the compose file reserves all GPUs (`driver: nvidia`).
+
+## Notes
+
+- Image is digest-pinned and managed by Renovate.
+- RTX 2060 Super (8 GB VRAM) fits QLoRA fine-tuning up to ~8B models. See ADR 0006.
+- vLLM standby is enabled (image default): GPU memory is pre-reserved for the API even when idle.

--- a/docker/deploy/unsloth/compose.yaml
+++ b/docker/deploy/unsloth/compose.yaml
@@ -1,0 +1,31 @@
+---
+volumes:
+  workspace:
+    external: false
+    name: unsloth_workspace
+    driver: local
+
+services:
+  unsloth:
+    scale: 1 # scale to 0 if you want to stop the service without losing data
+    container_name: unsloth
+    image: unsloth/unsloth:2026.5.9-pt2.10.0-vllm-0.16.0-cu12.8-studio-release-v0.1.43-beta-2026-MAY-31@sha256:f21629b9ae4ed11231768edfaed0f40d41d85d6ea9a71e8096a3d96ea0311772
+    env_file:
+      - ${SOPS_ENV_FILE:-sops.env}
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: all
+      # HF_TOKEN=${HF_TOKEN} # uncomment and add HF_TOKEN to sops.env to pull gated models
+    ports:
+      - 8000:8000 # Studio UI + OpenAI/Anthropic API (all interfaces)
+      - "127.0.0.1:8888:8888" # Jupyter Lab (localhost only)
+    restart: unless-stopped
+    volumes:
+      - workspace:/workspace
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker/red/unsloth/.env
+++ b/docker/red/unsloth/.env
@@ -1,0 +1,1 @@
+TARGET=red

--- a/docker/red/unsloth/compose.yaml
+++ b/docker/red/unsloth/compose.yaml
@@ -1,0 +1,1 @@
+../../deploy/unsloth/compose.yaml

--- a/docker/red/unsloth/sops.env
+++ b/docker/red/unsloth/sops.env
@@ -1,0 +1,9 @@
+JUPYTER_PASSWORD=ENC[AES256_GCM,data:W3FgBa71tvMYFRUW7xzFSLcYevhi6dqYruD3/cLClvU=,iv:uqeO+65RIAXFA/8aRrTqaEKy1v4TXnFlTRZi63xRZcE=,tag:8wySejRt/BeqtQ9mgROEFA==,type:str]
+USER_PASSWORD=ENC[AES256_GCM,data:gNiEaWtCGrDHChI6zrXyEFkw9jNxdwtkzjX/gbQ2qaM=,iv:kAQ2rGp8K+YB4doDcK3remTSLFEqoKN6fRE8ftLhm6M=,tag:VoB1ve3+Clqbm2TRVgAPTw==,type:str]
+UNSLOTH_STUDIO_PASSWORD=ENC[AES256_GCM,data:VSttSv0oJyvbqruPua8u/IiWGVaKJYAvWM/5XC2hOxo=,iv:5NmumCCYJXjiIk4aLDflct75XVyfu4Sv3QzE56YI7vU=,tag:YN4GG656WXglPKm61vTb0g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiV3BmaVo5VXhwa1B1ckRN\nUDVUbmtTdEk3a3pTMVJHZWUxdE5ZWjd5WVJZCjN5Ym04SlR4dzhmMWVkZDc3VzRW\naWpENU9rY2x3dS9RRnJyeHVnRk1pSU0KLS0tIGpoVUNHT20zd1ZiKzJ1eC95VHVN\nUXZKQlN1QkVuK3RpVTZ2T0doK1N1d1UKIGTITkjHm1OfmJSymFOklApGsaFEs1DS\nk1uebzQzftX9xWKaRTNihuRl1r4XDyGS8zEOm6wIv3JRTgqvE0wdnQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age16pcjw9pvhx2lnx382hrgcpydpjvjz6r8u22wflm228cakedrlgdqzlwx4s
+sops_lastmodified=2026-08-15T23:35:28Z
+sops_mac=ENC[AES256_GCM,data:hNx8NZz/3N2qXT5UDqc3cDO4OJFG0lvx8N5n3ap1Q85QFLnYfO+dS2pECeq7PtRvbTtd9+aXhEuRCCf2pv5UyfF5B2nOO79hAz6XcxESZ7EoXQlWi9O2ofrkGZtv8Ak97C4Bboqm1CMDm8DiC/tSL6/UFrvO3lIQJp8iH93a/Ko=,iv:KxhyoP14mpQ50y5PCzZAab6+4TctU13XIDHBqTOaMy4=,tag:jwOEheznigCYpQS2RfNHmQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/docs/superpowers/plans/2026-08-16-unsloth-doco-cd.md
+++ b/docs/superpowers/plans/2026-08-16-unsloth-doco-cd.md
@@ -1,0 +1,309 @@
+# Unsloth on red (doco-cd) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy the Unsloth LLM fine-tuning toolkit (Studio UI + OpenAI/Anthropic API on port 8000, Jupyter on 8888) on the "red" desktop workstation via the doco-cd GitOps-for-Docker system, with SOPS-encrypted passwords.
+
+**Architecture:** A new doco-cd workload is defined per-target under `docker/red/unsloth/` (compose.yaml + sops.env + .env) following the busybox-enc pattern, with a non-deployed shared reference compose under `docker/deploy/unsloth/`. doco-cd polls the git repo every 180s, decrypts `sops.env` via its age key, and runs the compose project with NVIDIA GPU passthrough. The image is digest-pinned and Renovate-managed like ollama/comfyui.
+
+**Tech Stack:** Docker Compose, doco-cd, SOPS (age), NVIDIA container runtime, Renovate, pre-commit/yamllint/markdownlint.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md`
+
+---
+
+## Context for the implementer
+
+- doco-cd workload config: `docker/.doco-cd.red.yaml` (entries separated by `---`).
+- Reference patterns (read these first): `docker/red/busybox-enc/` (target instance + sops.env), `docker/deploy/busybox-enc/README.md` (docs style), `docker/deploy/ollama/compose.yaml` (NVIDIA GPU pattern, digest-pinned image).
+- `.sops.yaml` already contains creation rule `docker/red/.*/sops\.env$` with the red age public key — NO .sops.yaml changes needed.
+- SOPS binary: managed via mise (`aqua:getsops/sops` = 3.13.3). Use `mise x sops -- <cmd>` if `sops` is not on PATH.
+- yamllint requires `---` document start on every YAML file (`.yamllint.yaml` `document-start: present`).
+- The user's age private key is on the red host / user workstation — a subagent CANNOT decrypt sops.env. Implementer verifies encryption succeeded (file contains `ENC[AES256_GCM,...]` lines), and the USER runs the final `sops --decrypt` check.
+- The plan's spec is already committed on branch `feature/unsloth-doco-cd`; implementation happens on that branch.
+- The implementer is authorized and expected to add any type hints, docstrings, lint suppressions, or repo config updates needed to pass CI/linters for the files in this plan.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `docker/deploy/unsloth/compose.yaml` | Shared reference compose (NOT deployed) — blueprint for other targets |
+| `docker/red/unsloth/compose.yaml` | Deployed target instance (full copy of shared, busybox-enc style) |
+| `docker/red/unsloth/sops.env` | SOPS-encrypted dotenv: JUPYTER_PASSWORD, USER_PASSWORD, UNSLOTH_STUDIO_PASSWORD |
+| `docker/red/unsloth/.env` | `TARGET=red` |
+| `docker/.doco-cd.red.yaml` | Appended workload entry for unsloth |
+| `docker/deploy/unsloth/README.md` | Workload documentation (busybox-enc README style) |
+
+### Task 1: Resolve and pin the Unsloth image tag + digest
+
+**Files:** none (research step)
+
+- [ ] **Step 1: Query current Docker Hub tags for unsloth/unsloth**
+
+Run:
+```bash
+curl -s 'https://hub.docker.com/v2/repositories/unsloth/unsloth/tags?page_size=100&ordering=last_updated' | jq -r '.results[].name' | head -20
+```
+Expected: a list of tags. The newest tag contains `-studio-` (e.g. `2026.5.9-pt2.10.0-vllm-0.16.0-cu12.8-studio-release-v0.1.43-beta-2026-MAY-31`). Pick the newest `-studio-` tag — that is the `<STUDIO_TAG>` used below.
+
+- [ ] **Step 2: Resolve the digest for that tag**
+
+Run:
+```bash
+docker pull unsloth/unsloth:<STUDIO_TAG> && docker inspect --format '{{index .RepoDigests 0}}' unsloth/unsloth:<STUDIO_TAG>
+```
+Expected: `<STUDIO_TAG>@sha256:<DIGEST>` (e.g. `@sha256:9f4a1f...`). Record the full `<STUDIO_TAG>@sha256:<DIGEST>` — it is used verbatim in Tasks 2 and 3.
+
+If Docker is not available on the machine, use skopeo or crane instead, e.g. `crane digest unsloth/unsloth:<STUDIO_TAG>` (returns just the sha256). Record it.
+
+### Task 2: Create the shared reference compose
+
+**Files:**
+- Create: `docker/deploy/unsloth/compose.yaml`
+
+- [ ] **Step 1: Write `docker/deploy/unsloth/compose.yaml`**
+
+Content (replace `<STUDIO_TAG>@sha256:<DIGEST>` with the value from Task 1):
+
+```yaml
+---
+volumes:
+  workspace:
+    external: false
+    name: unsloth_workspace
+    driver: local
+
+services:
+  unsloth:
+    scale: 1 # scale to 0 if you want to stop the service without losing data
+    container_name: unsloth
+    image: unsloth/unsloth:<STUDIO_TAG>@sha256:<DIGEST>
+    env_file:
+      - ${SOPS_ENV_FILE:-sops.env}
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: all
+      # HF_TOKEN=${HF_TOKEN} # uncomment and add HF_TOKEN to sops.env to pull gated models
+    ports:
+      - 8000:8000 # Studio UI + OpenAI/Anthropic API (all interfaces)
+      - "127.0.0.1:8888:8888" # Jupyter Lab (localhost only)
+    restart: unless-stopped
+    volumes:
+      - workspace:/workspace
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+- [ ] **Step 2: Lint the file**
+
+Run: `yamllint docker/deploy/unsloth/compose.yaml`
+Expected: no errors (line-length is warning-level, max 120).
+
+### Task 3: Create the deployed target instance
+
+**Files:**
+- Create: `docker/red/unsloth/compose.yaml`
+
+- [ ] **Step 1: Write `docker/red/unsloth/compose.yaml`**
+
+Copy the EXACT content from Task 2 Step 1 (same image, same env_file, same volume). This is the file doco-cd actually deploys.
+
+- [ ] **Step 2: Lint the file**
+
+Run: `yamllint docker/red/unsloth/compose.yaml`
+Expected: no errors.
+
+### Task 4: Create the SOPS-encrypted secrets
+
+**Files:**
+- Create: `docker/red/unsloth/sops.env` (encrypted)
+
+- [ ] **Step 1: Generate random passwords and write a plaintext temp file**
+
+Run:
+```bash
+mkdir -p docker/red/unsloth
+cat > /tmp/unsloth-sops.env <<EOF
+JUPYTER_PASSWORD=$(openssl rand -base64 24)
+USER_PASSWORD=$(openssl rand -base64 24)
+UNSLOTH_STUDIO_PASSWORD=$(openssl rand -base64 24)
+EOF
+```
+IMPORTANT: this plaintext file must NEVER be committed. It lives in /tmp only.
+
+- [ ] **Step 2: Encrypt in place with SOPS**
+
+Run:
+```bash
+mise x sops -- --encrypt --in-place --input-type dotenv --output-type dotenv /tmp/unsloth-sops.env
+```
+(If `sops` is directly on PATH: `sops --encrypt --in-place --input-type dotenv --output-type dotenv /tmp/unsloth-sops.env`)
+
+Then move it into place: `mv /tmp/unsloth-sops.env docker/red/unsloth/sops.env`
+
+- [ ] **Step 3: Verify encryption succeeded**
+
+Run: `rg -c 'ENC\[AES256_GCM' docker/red/unsloth/sops.env`
+Expected: output `3` (one per secret value). Also confirm the file ends with the `sops_*` metadata lines (recipient `age16pcjw9...`, version).
+
+NOTE: do NOT run `sops --decrypt` on it — your session lacks the age private key. The user verifies decryption after the branch is pushed (see Verification).
+
+- [ ] **Step 4: Confirm no plaintext leaked**
+
+Run: `git status --porcelain` and visually confirm no `/tmp` file or plaintext `sops.env` is tracked/staged.
+
+### Task 5: Create the .env for the target
+
+**Files:**
+- Create: `docker/red/unsloth/.env`
+
+- [ ] **Step 1: Write `docker/red/unsloth/.env`**
+
+Content:
+```
+TARGET=red
+```
+
+### Task 6: Wire the workload into doco-cd
+
+**Files:**
+- Modify: `docker/.doco-cd.red.yaml` (append)
+
+- [ ] **Step 1: Append the workload entry**
+
+Append to the end of `docker/.doco-cd.red.yaml`:
+```yaml
+---
+name: unsloth
+working_dir: docker/red/unsloth
+env_files:
+  - .env
+```
+Do not modify existing entries.
+
+- [ ] **Step 2: Lint the file**
+
+Run: `yamllint docker/.doco-cd.red.yaml`
+Expected: no errors.
+
+### Task 7: Write the workload README
+
+**Files:**
+- Create: `docker/deploy/unsloth/README.md`
+
+- [ ] **Step 1: Write `docker/deploy/unsloth/README.md`**
+
+Content:
+
+```markdown
+# unsloth
+
+Unsloth — LLM fine-tuning toolkit with Unsloth Studio (web UI + OpenAI/Anthropic-compatible API) and Jupyter Lab, running on the NVIDIA GPU of the target host.
+
+## Layout
+
+- `compose.yaml`: shared compose definition (uses `SOPS_ENV_FILE`, default `sops.env`)
+- `docker/red/unsloth/compose.yaml`: red target instance
+- `docker/red/unsloth/sops.env`: red encrypted dotenv (JUPYTER_PASSWORD, USER_PASSWORD, UNSLOTH_STUDIO_PASSWORD)
+- `docker/red/unsloth/.env`: target identifier
+
+## Ports
+
+- `8000`: Unsloth Studio UI + API — bound on all interfaces (LAN).
+- `8888`: Jupyter Lab — bound to `127.0.0.1` only.
+
+## Secrets
+
+Passwords are stored in the target's SOPS-encrypted `sops.env`:
+
+- `JUPYTER_PASSWORD` — Jupyter Lab login.
+- `USER_PASSWORD` — sudo inside the container.
+- `UNSLOTH_STUDIO_PASSWORD` — Studio admin password (avoids interactive first-run bootstrap).
+
+## Manual decrypt check
+
+```bash
+sops --decrypt docker/red/unsloth/sops.env
+```
+
+## Runtime requirement on doco-cd host
+
+- `doco-cd` must have a valid age private key configured via `SOPS_AGE_KEY_FILE` (or `SOPS_AGE_KEY`).
+- NVIDIA driver + nvidia-container-toolkit must be installed; the compose file reserves all GPUs (`driver: nvidia`).
+
+## Notes
+
+- Image is digest-pinned and managed by Renovate.
+- RTX 2060 Super (8 GB VRAM) fits QLoRA fine-tuning up to ~8B models. See ADR 0006.
+- vLLM standby is enabled (image default): GPU memory is pre-reserved for the API even when idle.
+```
+
+- [ ] **Step 2: Lint the markdown**
+
+Run: `npx markdownlint-cli2 --config .markdownlint.yaml docker/deploy/unsloth/README.md` (or `markdownlint` if configured in this repo)
+Expected: no errors.
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Lint all changed YAML**
+
+Run:
+```bash
+yamllint docker/deploy/unsloth/compose.yaml docker/red/unsloth/compose.yaml docker/.doco-cd.red.yaml
+```
+Expected: no errors.
+
+- [ ] **Step 2: Run repo pre-commit on changed files**
+
+Run: `pre-commit run --files docker/deploy/unsloth/compose.yaml docker/red/unsloth/compose.yaml docker/red/unsloth/sops.env docker/.doco-cd.red.yaml docker/deploy/unsloth/README.md`
+Expected: all hooks pass (gitleaks must NOT flag sops.env — it is encrypted). If a hook fails, fix the file (do not bypass hooks).
+
+- [ ] **Step 3: Confirm the workload wiring**
+
+Run: `git diff -- docker/.doco-cd.red.yaml`
+Expected: only the appended `---` + unsloth entry. Confirm `working_dir: docker/red/unsloth` matches the created directory.
+
+### Task 9: Commit
+
+- [ ] **Step 1: Stage only the new files**
+
+Run:
+```bash
+git add docker/deploy/unsloth/compose.yaml docker/red/unsloth/compose.yaml docker/red/unsloth/sops.env docker/red/unsloth/.env docker/.doco-cd.red.yaml docker/deploy/unsloth/README.md
+```
+Do NOT stage any other files (there are unrelated envoy-pocketid changes and other untracked docs in the working tree).
+
+- [ ] **Step 2: Verify staged set**
+
+Run: `git status` — confirm ONLY the 6 unsloth files are staged.
+
+- [ ] **Step 3: Commit**
+
+Run: `git commit -m "feat(unsloth): add unsloth workload for red via doco-cd"`
+Expected: pre-commit hooks run and pass; commit created.
+
+- [ ] **Step 4: Verify**
+
+Run: `git log --oneline -2` — show the new commit on top of `docs(spec): ...`.
+
+## Rollout / Verification (after push)
+
+1. Push `feature/unsloth-doco-cd` to origin.
+2. On the red host (or with the user's age key): `sops --decrypt docker/red/unsloth/sops.env` must print the three passwords.
+3. doco-cd on red picks up the workload within 180s — no manual action needed.
+4. First pull downloads ~7 GB compressed (13 GiB image); Studio takes a few minutes to come up.
+5. Browse `http://192.168.1.22:8000` → Studio login with `UNSLOTH_STUDIO_PASSWORD`. On red, `http://127.0.0.1:8888` → Jupyter with `JUPYTER_PASSWORD`.
+6. Inside the container `nvidia-smi` shows the RTX 2060 Super.
+
+## Notes / Caveats
+
+- 8 GB VRAM: QLoRA fine-tuning feasible to ~8B models only (ADR 0006).
+- vLLM standby pre-reserves VRAM; set `UNSLOTH_VLLM_STANDBY=0` in the compose `environment` if training headroom is preferred (cold-start latency on API calls).
+- olla LLM proxy integration (kubernetes/main/apps/ai/olla) is future work — not in scope.
+
+---

--- a/docs/superpowers/plans/2026-08-16-unsloth-doco-cd.md
+++ b/docs/superpowers/plans/2026-08-16-unsloth-doco-cd.md
@@ -28,7 +28,7 @@
 | File | Responsibility |
 |---|---|
 | `docker/deploy/unsloth/compose.yaml` | Shared reference compose (NOT deployed) — blueprint for other targets |
-| `docker/red/unsloth/compose.yaml` | Deployed target instance (full copy of shared, busybox-enc style) |
+| `docker/red/unsloth/compose.yaml` | Deployed target instance (symlink to shared compose, busybox-enc style) |
 | `docker/red/unsloth/sops.env` | SOPS-encrypted dotenv: JUPYTER_PASSWORD, USER_PASSWORD, UNSLOTH_STUDIO_PASSWORD |
 | `docker/red/unsloth/.env` | `TARGET=red` |
 | `docker/.doco-cd.red.yaml` | Appended workload entry for unsloth |
@@ -111,7 +111,7 @@ Expected: no errors (line-length is warning-level, max 120).
 
 - [ ] **Step 1: Write `docker/red/unsloth/compose.yaml`**
 
-Copy the EXACT content from Task 2 Step 1 (same image, same env_file, same volume). This is the file doco-cd actually deploys.
+Create a symlink pointing at the shared reference compose: `ln -s ../../deploy/unsloth/compose.yaml docker/red/unsloth/compose.yaml` (repo convention — see `docker/red/busybox-enc/compose.yaml` which is mode 120000 symlink). doco-cd resolves the symlink and deploys the shared compose with the target's local `sops.env`/`.env`.
 
 - [ ] **Step 2: Lint the file**
 

--- a/docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md
+++ b/docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md
@@ -1,0 +1,385 @@
+# Deploy Unsloth on the Red Host via doco-cd — Design Spec
+
+**Date:** 2026-08-16
+**Status:** Proposed
+
+## Overview
+
+Deploy [Unsloth](https://unsloth.ai) — an LLM fine-tuning toolkit bundling
+Unsloth Studio (web UI + OpenAI/Anthropic-compatible API), Jupyter Lab, and an
+SSH server — on the "red" desktop workstation via the doco-cd GitOps-for-Docker
+system. The workload exposes Studio on port 8000 (LAN-reachable) and Jupyter on
+port 8888 (localhost-only), persists workspace data to a named Docker volume,
+and uses SOPS-encrypted secrets for all passwords.
+
+This spec documents the design in detail. Implementation has not started; an
+implementation plan will be written from this spec afterwards.
+
+## Context and Background
+
+### Unsloth
+
+Unsloth is an open-source LLM fine-tuning toolkit (Apache 2.0 for the core
+library, AGPL-3.0 for the container and Studio UI). The official Docker image
+`unsloth/unsloth` on Docker Hub bundles:
+
+- **Unsloth Studio** — web UI and OpenAI/Anthropic-compatible API server on port
+  8000.
+- **Jupyter Lab** — notebook environment on port 8888.
+- **SSH server** — on port 22 (not exposed in this deployment).
+
+The image is amd64-only, approximately 13 GiB uncompressed (~7 GB compressed
+pull), built on CUDA 12.8 and Python 3.12, and runs as a non-root user `unsloth`.
+
+### doco-cd
+
+[doco-cd](https://github.com/kimdre/doco-cd) is the GitOps-for-Docker system
+used to manage workloads on non-Kubernetes hosts. It polls the git repository
+every 180 seconds, decrypts SOPS-encrypted dotenv files at deploy time, and runs
+Docker Compose projects defined by `working_dir` paths relative to `docker/`.
+Target hosts are configured via `docker/.doco-cd.<target>.yaml` files.
+
+### Target Host: red
+
+The "red" host is a desktop workstation at `192.168.1.22` with an NVIDIA RTX
+2060 Super (8 GB VRAM, CUDA capability 7.5) and 64 GB system RAM. It is a
+doco-cd target defined in `docker/.doco-cd.red.yaml`, currently running:
+
+- `busybox-enc` (SOPS validation container)
+- `ollama` (local LLM inference)
+- `node-exporter` (Prometheus metrics)
+- `comfyui` (image generation)
+
+## Goals
+
+- Deploy Unsloth Studio and Jupyter Lab on the red workstation, managed by
+  doco-cd with the same GitOps workflow as existing workloads.
+- Expose Studio (web UI + API) on port 8000, reachable from the LAN.
+- Expose Jupyter Lab on port 8888, reachable from localhost only.
+- Persist models, workspace data, and Studio state across container restarts.
+- Store all passwords as SOPS-encrypted secrets from day one.
+- Follow the established busybox-enc pattern: a shared reference compose under
+  `docker/deploy/` alongside the target-specific instance under `docker/red/`.
+
+## Non-Goals
+
+- Exposing the SSH server (port 22) — not needed.
+- Reverse proxy or TLS termination in front of the Studio API — direct port
+  exposure on the LAN is sufficient for this use case.
+- Integration with the olla LLM proxy
+  (`kubernetes/main/apps/ai/olla/`) — documented as future work.
+- Fine-tuning models larger than ~8B parameters — hardware-constrained by 8 GB
+  VRAM (see VRAM Constraints below).
+- Multi-GPU or multi-host deployment — single GPU, single host.
+
+## Target Environment
+
+| Property | Value |
+|---|---|
+| Host | red (desktop workstation) |
+| IP | `192.168.1.22` |
+| GPU | NVIDIA RTX 2060 Super, 8 GB VRAM, CUDA capability 7.5 |
+| RAM | 64 GB |
+| OS | Linux (Docker host) |
+| doco-cd config | `docker/.doco-cd.red.yaml` |
+| SOPS age key | Configured in `.sops.yaml` creation rule `docker/red/.*/sops\.env$` |
+| Existing workloads | busybox-enc, ollama, node-exporter, comfyui |
+
+## Decisions
+
+### 1. Interfaces: Studio Web UI + Jupyter only
+
+**Decision:** Expose Studio (port 8000) and Jupyter Lab (port 8888). Do not
+expose SSH (port 22).
+
+**Rationale:** Studio provides the primary web UI and API. Jupyter provides
+notebook-based access for experimentation. SSH is unnecessary — the host is
+already accessible directly, and the container runs a non-root user.
+
+### 2. Networking: Port 8000 on all interfaces, Jupyter on localhost only
+
+**Decision:** Bind port 8000 on all interfaces (`0.0.0.0:8000:8000`) so Studio
+UI and API are LAN-reachable at `192.168.1.22:8000`. Bind Jupyter to localhost
+only (`127.0.0.1:8888:8888`).
+
+**Rationale:** Studio is the primary interface and should be accessible from
+other machines on the LAN (e.g., a laptop browser). Jupyter is a developer tool
+that does not need LAN exposure — SSH tunneling or direct host access is
+sufficient.
+
+### 3. API exposure: Direct port, no reverse proxy
+
+**Decision:** Expose port 8000 directly. No Caddy or other reverse proxy in
+front of the Studio API.
+
+**Rejected alternative:** A Caddy reverse proxy providing TLS termination and
+path-based routing. Rejected because:
+
+- The workload is LAN-only; TLS adds complexity without meaningful security
+  improvement on a trusted network.
+- The Studio API and UI share port 8000 — a proxy would need to handle both,
+  adding configuration overhead.
+- Simplicity is preferred for a single-user workstation workload. The user
+  explicitly rejected the proxy option.
+
+### 4. Storage: Single named Docker volume
+
+**Decision:** A single named volume `unsloth_workspace` mounted at `/workspace`.
+
+**Rationale:** The `/workspace` directory inside the Unsloth container holds:
+
+- `/workspace/.cache/huggingface` — downloaded models and datasets.
+- `/workspace/work` — user work (notebooks, scripts, fine-tuning outputs).
+- `/workspace/studio` — Studio state.
+
+A named volume persists across container restarts and image updates without
+requiring host-path management. A single volume is simpler than splitting into
+multiple volumes and matches the container's expectation of a unified workspace.
+
+### 5. Secrets: SOPS-encrypted dotenv with all passwords set from day one
+
+**Decision:** Create `docker/red/unsloth/sops.env` (SOPS-encrypted) containing
+`JUPYTER_PASSWORD`, `USER_PASSWORD`, and `UNSLOTH_STUDIO_PASSWORD` — all random
+values, all set before first deployment.
+
+**Rejected alternative: Relying on image defaults instead of setting
+passwords.** With env vars unset, the container does not auto-generate
+passwords. Jupyter falls back to a deterministic default password (`unsloth`),
+and Unsloth Studio has no auto-generation: when `UNSLOTH_STUDIO_PASSWORD` is
+unset it starts an interactive first-run bootstrap password prompt, and if no
+password is ever set it shuts down after `UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT`
+(default 1 hour). Rejected because:
+
+- The deterministic defaults are insecure and publicly well-known — relying on
+  them would leave the LAN-exposed Studio UI (port 8000) open with a default
+  password.
+- Studio's interactive bootstrap is unsuitable for a GitOps-managed (doco-cd),
+  unattended deployment: the first-run prompt cannot be answered headlessly,
+  and the container would shut down after one hour if no password is ever set.
+- SOPS-encrypted dotenv is the established pattern (busybox-enc) and provides
+  deterministic, version-controlled, recoverable secrets.
+
+The SOPS creation rule `docker/red/.*/sops\.env$` in `.sops.yaml` already covers
+the path `docker/red/unsloth/sops.env` — no `.sops.yaml` changes are needed.
+
+### 6. vLLM standby: Keep image default
+
+**Decision:** Keep `UNSLOTH_VLLM_STANDBY=1` (the image default). Do not override
+it.
+
+**Rationale:** The image sets this by default, which pre-reserves GPU memory for
+vLLM inference. Disabling it would save VRAM when not using the API but would
+add cold-start latency when the API is first used. The default behavior is
+acceptable for a workstation where the GPU is not heavily contended.
+
+### 7. Shared reference compose: Yes (busybox-enc pattern)
+
+**Decision:** Include `docker/deploy/unsloth/compose.yaml` as a non-deployed
+shared blueprint, alongside the deployed target instance at
+`docker/red/unsloth/compose.yaml`.
+
+**Rationale:** This follows the established busybox-enc pattern exactly:
+
+- `docker/deploy/busybox-enc/compose.yaml` — shared reference (not deployed
+  directly).
+- `docker/red/busybox-enc/compose.yaml` — target-specific instance (deployed by
+  doco-cd).
+
+The shared reference serves as documentation and a template for future targets.
+The target-specific instance is what doco-cd actually deploys.
+
+**Rejected alternative: Shared deploy dir without per-target secrets.** Using
+only `docker/deploy/unsloth/` as the deployed path (like ollama or comfyui)
+would mean no target-specific SOPS secrets. Rejected because:
+
+- Unsloth requires passwords (Jupyter, Studio, sudo) that are target-specific
+  secrets — these need SOPS encryption, which requires a target-specific path
+  matching the `.sops.yaml` creation rule.
+- The busybox-enc pattern exists specifically for workloads that need per-target
+  encrypted secrets.
+
+## Implementation Plan
+
+### File 1: `docker/deploy/unsloth/compose.yaml`
+
+Shared reference compose (blueprint, NOT deployed on red).
+
+```yaml
+---
+services:
+  unsloth:
+    scale: 1
+    container_name: unsloth
+    image: unsloth/unsloth:<dated-studio-tag>@sha256:<digest>
+    env_file:
+      - ${SOPS_ENV_FILE:-sops.env}
+    ports:
+      - "8000:8000"
+      - "127.0.0.1:8888:8888"
+    volumes:
+      - workspace:/workspace
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      # - HF_TOKEN=<set-in-sops.env-if-needed>
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+volumes:
+  workspace:
+    name: unsloth_workspace
+    driver: local
+```
+
+**Notes:**
+
+- Image tag and digest to be determined at implementation time (latest
+  dated-studio tag from Docker Hub, digest-pinned for Renovate management).
+- `HF_TOKEN` is commented out as an example — can be added to `sops.env` if
+  Hugging Face Hub access is needed for gated models.
+- NVIDIA device reservation follows the standard Docker Compose GPU passthrough
+  pattern.
+
+### File 2: `docker/red/unsloth/compose.yaml`
+
+Deployed target instance. Same content as the shared reference compose above.
+Container name `unsloth`. This is the file doco-cd actually deploys.
+
+### File 3: `docker/red/unsloth/sops.env`
+
+SOPS-encrypted dotenv file. Plaintext content (before encryption):
+
+```dotenv
+JUPYTER_PASSWORD=<random>
+USER_PASSWORD=<random>
+UNSLOTH_STUDIO_PASSWORD=<random>
+```
+
+All three values are random strings generated at implementation time. Encrypted
+with the age key configured in `.sops.yaml` for the `docker/red/.*/sops\.env$`
+path regex.
+
+### File 4: `docker/red/unsloth/.env`
+
+```dotenv
+TARGET=red
+```
+
+Matches the busybox-enc pattern — identifies the target for doco-cd.
+
+### File 5: `docker/.doco-cd.red.yaml` (append)
+
+Append a new workload entry to the existing file:
+
+```yaml
+---
+name: unsloth
+working_dir: docker/red/unsloth
+env_files:
+  - .env
+```
+
+This tells doco-cd to deploy the compose project at `docker/red/unsloth/` with
+the `.env` file (which sets `TARGET=red`). doco-cd automatically decrypts
+`sops.env` via the `env_file` reference in `compose.yaml`.
+
+### File 6: `docker/deploy/unsloth/README.md`
+
+Workload documentation mirroring the `docker/deploy/busybox-enc/README.md`
+style. Contents:
+
+- Purpose: LLM fine-tuning toolkit with Studio web UI and Jupyter Lab.
+- Layout: list of files (shared compose, target instances, encrypted secrets).
+- Manual decrypt check: `sops --decrypt docker/red/unsloth/sops.env`.
+- Runtime requirements: doco-cd with age key, NVIDIA GPU with Docker runtime.
+- Ports: 8000 (Studio, all interfaces), 8888 (Jupyter, localhost only).
+
+## Verification
+
+1. **Pre-commit SOPS check:** `sops --decrypt docker/red/unsloth/sops.env`
+   succeeds locally, confirming the age key and creation rule are correctly
+   wired.
+2. **doco-cd pickup:** After push, doco-cd on red picks up the new workload
+   automatically on its next 180-second poll cycle. No manual action on the
+   host is required.
+3. **Image pull:** First deployment pulls approximately 7 GB compressed /
+   13 GiB uncompressed. Allow time for the initial download.
+4. **Studio access:** Browse to `http://192.168.1.22:8000` — Studio UI should
+   load, prompting for `UNSLOTH_STUDIO_PASSWORD`.
+5. **Jupyter access:** On the red host, browse to `http://127.0.0.1:8888` —
+   Jupyter Lab should load, prompting for `JUPYTER_PASSWORD`.
+6. **GPU passthrough:** Inside the container, `nvidia-smi` should show the RTX
+   2060 Super with 8 GB VRAM.
+
+## VRAM Constraints
+
+The RTX 2060 Super has 8 GB VRAM. This imposes hard limits on QLoRA
+fine-tuning:
+
+| Model size | Approximate VRAM | Feasibility |
+|---|---|---|
+| 7B | ~5 GB | Comfortable |
+| 8B | ~6 GB | Comfortable |
+| 14B | ~8.5 GB | Borderline / likely OOM |
+| 70B+ | 30+ GB | Not feasible |
+
+These constraints are consistent with the findings documented in
+[ADR 0006](../../decisions/0006-local-llm-agentic-coding-not-feasable-on-8gb-vram.md),
+which evaluated the RTX 2060 Super's 8 GB VRAM as a hard constraint for local
+LLM workloads on this workstation.
+
+The RTX 2060 Super has CUDA capability 7.5 (Turing architecture), which meets
+Unsloth's minimum requirement of CUDA capability >= 7.0.
+
+With `UNSLOTH_VLLM_STANDBY=1` (the image default), vLLM pre-reserves GPU memory
+for inference, reducing the VRAM available for fine-tuning. If fine-tuning
+larger models is needed, setting `UNSLOTH_VLLM_STANDBY=0` in the environment
+would free that reservation — at the cost of cold-start latency when the API is
+first used.
+
+## Future Work
+
+### olla LLM proxy integration
+
+The olla LLM proxy (`kubernetes/main/apps/ai/olla/app/config/config.yaml`)
+currently supports ollama, lm-studio, and llamacpp endpoint types. Unsloth
+Studio exposes an OpenAI/Anthropic-compatible API on port 8000, which could be
+registered as an olla endpoint — allowing cluster-based applications to route
+inference requests to the Unsloth API on the red workstation.
+
+This is not in scope for this deployment. Integration would require:
+
+- Confirming olla supports a generic OpenAI-compatible endpoint type (or adding
+  one).
+- Network routing from the Kubernetes cluster to `192.168.1.22:8000`.
+- Deciding whether fine-tuned models served by Unsloth should appear alongside
+  ollama models in the proxy's model list.
+
+### Additional targets
+
+If Unsloth is needed on other doco-cd hosts (e.g., a future workstation with
+more VRAM), the shared reference compose at `docker/deploy/unsloth/compose.yaml`
+serves as the template — create a new `docker/<target>/unsloth/` directory with
+target-specific `compose.yaml`, `sops.env`, and `.env`, and append a workload
+entry to the target's `.doco-cd.<target>.yaml`.
+
+## References
+
+- [Unsloth](https://unsloth.ai) — LLM fine-tuning toolkit.
+- [Unsloth Docker Hub](https://hub.docker.com/r/unsloth/unsloth) — official
+  container image.
+- [doco-cd](https://github.com/kimdre/doco-cd) — GitOps-for-Docker system.
+- ADR 0006:
+  [Local LLM Agentic Coding not feasible on 8 GB VRAM](../../decisions/0006-local-llm-agentic-coding-not-feasable-on-8gb-vram.md)
+- Reference pattern: `docker/deploy/busybox-enc/` and `docker/red/busybox-enc/`
+  (shared reference + target-specific instance with SOPS secrets).
+- SOPS configuration: `.sops.yaml` — creation rule
+  `docker/red/.*/sops\.env$`.
+- doco-cd target config: `docker/.doco-cd.red.yaml`.
+- olla LLM proxy: `kubernetes/main/apps/ai/olla/app/config/config.yaml`.


### PR DESCRIPTION
## Summary
- Deploy Unsloth (LLM fine-tuning toolkit) on the red doco-cd host: Studio UI + OpenAI/Anthropic-compatible API on port 8000 (LAN), Jupyter Lab on 8888 (localhost only)
- New doco-cd workload `docker/red/unsloth/` following the busybox-enc pattern: symlinked compose, SOPS-encrypted sops.env (JUPYTER_PASSWORD, USER_PASSWORD, UNSLOTH_STUDIO_PASSWORD), .env with TARGET=red
- Shared reference compose + README under `docker/deploy/unsloth/`; digest-pinned `unsloth/unsloth` image (Renovate-managed) with NVIDIA GPU passthrough
- Design spec: `docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md`

## Test Plan
- [x] All pre-commit hooks pass (yamllint, gitleaks on encrypted sops.env, markdownlint)
- [x] `sops --decrypt docker/red/unsloth/sops.env` succeeds on the red host (age key check — requires user's private key)
- [x] doco-cd on red picks up the workload within 180s poll; Studio reachable at http://192.168.1.22:8000 with UNSLOTH_STUDIO_PASSWORD
- [x] `nvidia-smi` inside container shows RTX 2060 Super
