### PR TITLE
feat(hermes-agent): route inference via new-api gateway

### DIFF
--- a/kubernetes/main/apps/hermes-agent/app/configmap.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/configmap.yaml
@@ -6,12 +6,21 @@ metadata:
 data:
   config.yaml: |
     model:
-      default: deepseek-v4-pro
-      provider: opencode-go
+      default: qwen3.8-flash-next
+      provider: techtales
+      base_url: https://techtales.ai/v1
+      api_mode: chat_completions
+    providers:
+      techtales:
+        base_url: https://techtales.ai/v1
+        api_mode: chat_completions
+        key_env: TECHTALES_API_KEY
+        default_model: qwen3.8-flash-next
+    fallback_providers:
+    - provider: opencode-go
+      model: glm-5.3-flash
       base_url: https://opencode.ai/zen/go/v1
       api_mode: chat_completions
-    providers: {}
-    fallback_providers:
     - provider: opencode-zen
       model: big-pickle
       base_url: https://opencode.ai/zen/v1
@@ -177,30 +186,30 @@ data:
         trace: disabled
     auxiliary:
       vision:
-        provider: custom
-        model: gemma4:e4b
-        base_url: http://olla.ai.svc.cluster.local:40114/olla/ollama/v1
+        provider: techtales
+        model: qwen3.8-flash-next
+        base_url: ''
         api_key: ''
         timeout: 120
         extra_body: {}
         download_timeout: 30
       web_extract:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: qwen3.8-flash-next
         base_url: ''
         api_key: ''
         timeout: 360
         extra_body: {}
       compression:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: qwen3.8-flash-next
         base_url: ''
         api_key: ''
         timeout: 120
         extra_body: {}
       skills_hub:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: qwen3.8-flash-next
         base_url: ''
         api_key: ''
         timeout: 30
@@ -220,8 +229,8 @@ data:
         timeout: 30
         extra_body: {}
       title_generation:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: gemma3:1b
         base_url: ''
         api_key: ''
         timeout: 30
@@ -234,8 +243,8 @@ data:
         timeout: 120
         extra_body: {}
       kanban_decomposer:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: qwen3.8-flash-next
         base_url: ''
         api_key: ''
         timeout: 180
@@ -248,8 +257,8 @@ data:
         timeout: 60
         extra_body: {}
       curator:
-        provider: opencode-go
-        model: deepseek-v4-flash
+        provider: techtales
+        model: qwen3.8-flash-next
         base_url: ''
         api_key: ''
         timeout: 600
@@ -610,25 +619,3 @@ data:
     image_gen:
       use_gateway: false
       model: fal-ai/flux-2-pro
-
-    # ── Fallback Model ────────────────────────────────────────────────────
-    # Automatic provider failover when primary is unavailable.
-    # Uncomment and configure to enable. Triggers on rate limits (429),
-    # overload (529), service errors (503), or connection failures.
-    #
-    # Supported providers:
-    #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
-    #   openai-codex (OAuth — hermes auth) — OpenAI Codex
-    #   nous         (OAuth — hermes auth) — Nous Portal
-    #   zai          (ZAI_API_KEY)         — Z.AI / GLM
-    #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
-    #   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
-    #   minimax      (MINIMAX_API_KEY)     — MiniMax
-    #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
-    #   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
-    #
-    # For custom OpenAI-compatible endpoints, add base_url and key_env.
-    #
-    fallback_model:
-      provider: opencode-go
-      model: deepseek-v4-flash

--- a/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/external-secret.yaml
@@ -24,6 +24,7 @@ spec:
         OPENCODE_GO_API_KEY: "{{ .OPENCODE_GO_API_KEY }}"
         OPENCODE_ZEN_API_KEY: "{{ .OPENCODE_ZEN_API_KEY }}"
         HERMES_WEBUI_PASSWORD: "{{ .HERMES_WEBUI_PASSWORD }}"
+        TECHTALES_API_KEY: "{{ .TECHTALES_API_KEY }}"
   dataFrom:
     - extract:
         key: infra/kubernetes/main/hermes-agent/${APP}

--- a/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
+++ b/kubernetes/main/apps/hermes-agent/app/network-policy.yaml
@@ -68,6 +68,13 @@ spec:
       ports:
         - protocol: TCP
           port: 40114
+    # Allow egress to new-api gateway on bifrost (techtales.ai -> 192.168.100.10)
+    - to:
+        - ipBlock:
+            cidr: 192.168.100.10/32
+      ports:
+        - protocol: TCP
+          port: 443
     # Allow Internet egress but drop internal clusters to enforce isolation
     - to:
         - ipBlock:


### PR DESCRIPTION
Route hermes-agent inference through the new-api gateway on bifrost (`techtales.ai`).

**Changes**
- `configmap.yaml`: add `providers.techtales` (new-api, `key_env: TECHTALES_API_KEY`), switch default + auxiliary models to it, prepend opencode-go fallback, drop stale legacy `fallback_model`
- `external-secret.yaml`: add `TECHTALES_API_KEY` to the secret template
- `network-policy.yaml`: allow egress to the gateway (`192.168.100.10:443`; RFC1918, so previously blocked)

**Note:** requires `TECHTALES_API_KEY` present in OpenBao under `infra/kubernetes/main/hermes-agent/<user>` for all four instances.