### PR TITLE
feat(arcane): add Arcane Docker UI on bifrost

### DIFF
--- a/docker/.doco-cd.bifrost.yaml
+++ b/docker/.doco-cd.bifrost.yaml
@@ -17,3 +17,8 @@ name: traefik
 working_dir: docker/bifrost/traefik
 env_files:
   - .env
+---
+name: arcane
+working_dir: docker/bifrost/arcane
+env_files:
+  - .env

--- a/docker/bifrost/arcane/.env
+++ b/docker/bifrost/arcane/.env
@@ -1,0 +1,11 @@
+TARGET=bifrost
+USER_ID=1000
+GROUP_ID=1000
+# Arcane v2 blocks cookie-authenticated cross-origin writes: APP_URL must exactly match
+# the public URL (scheme + host, no port), otherwise requests fail with 403.
+APP_URL=https://arcane.techtales.io
+# Docker bridge range so Arcane sees the real client IP behind Traefik.
+TRUSTED_PROXIES=172.16.0.0/12
+# Debug port bound to loopback only; Traefik reaches the container over the `apps` network.
+WEB_HOST=127.0.0.1
+WEB_PORT=3552

--- a/docker/bifrost/arcane/compose.yaml
+++ b/docker/bifrost/arcane/compose.yaml
@@ -1,0 +1,22 @@
+---
+# Include shim — the actual service definition is shared: docker/deploy/arcane/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file, the /app/data volume) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/arcane/compose.yaml
+    project_directory: .
+
+services:
+  arcane:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.arcane.rule=Host(`arcane.techtales.io`)"
+      - "traefik.http.routers.arcane.entrypoints=websecure"
+      - "traefik.http.services.arcane.loadbalancer.server.port=3552"
+    dns:
+      - 192.168.100.1
+      - 1.1.1.2

--- a/docker/bifrost/arcane/sops.env
+++ b/docker/bifrost/arcane/sops.env
@@ -1,0 +1,8 @@
+#ENC[AES256_GCM,data:FxeJa79IHWOwafKe8auycplEyW0D+K1PYU1TEtVmguVxyAHpJY9t4kfInlJc8M6PqZ7IZG2MKBYperB7Dz/C9rjmDRcjKDWVoaj8Xlae1L0x6ZjYgXc=,iv:givkiFyXaXpBKEHl3nOafEZu4WuqQ13tMZ/oCn9RCYk=,tag:5oSoyEuvdkDfL3aEfTlPRw==,type:comment]
+ENCRYPTION_KEY=ENC[AES256_GCM,data:0QTa7APqOgjS9D7zsGdBk4QicwcKpEke8dkfjCtIRsijpqsC+vG7iRCZbV0DlzwMx88LKNtaNU8gDL7e9N133Q==,iv:vK5gjSL7CpT9oqXZmlMXoP+f/ob3jrKvmooAYBkemqM=,tag:WE5OeCFu45+jOZcmv7kz2g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwWjJLMlZ1UWJCNFF1WVhY\nL3BXUUh1QmRDRnRMNjJuc2ZEOUV3NW5YRFZFClU1cU1WTnBnYmc4cDBRQUdvRzNk\nWlN1c2xZd3lKYVlpa3hocVl0VkRvVzQKLS0tIDJxSDFxVVpXaTBLZEJ3Mm5hbnpP\nUWd6ZkpHVUtLVXMvNWZhLzljNktwRXcKv95CgMkgOUBCB5oTHgUKsZN5SvV40RyB\n+LvaGuDMhaxqMFqML5TMW+nHT7nQLXwXOA6+1r60l5l7wQDm5LkP3w==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age16fdxndp7s8fmv0r9qa2f8ymwy7gca0eleev52f3qu9mwqvsqmaaqkvj5ja
+sops_lastmodified=2026-09-12T07:00:09Z
+sops_mac=ENC[AES256_GCM,data:Y0wD2PrzbYGN0vS1U67EdyIzNTFTRvJlFdRczKnu4ragDU+KXTx1Deh9q+8RUXyXVVRIcIjU+KV4iV/mTOKu94sEQNEKfxDGRkIiUtZp+l1rftO7smmrX1Ow2LtWQl66gGnVuijc8+jpyvxX+OhQecxY9QKNjwjQuywAhXYv258=,iv:b1Yc7NeELNJQdAV7qYHeMPuomCY6YAfC5evn6/kIbNI=,tag:9nazgcr4O+is5yEhZzppDA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/docker/deploy/arcane/compose.yaml
+++ b/docker/deploy/arcane/compose.yaml
@@ -1,0 +1,59 @@
+---
+networks:
+  apps:
+    name: apps
+    external: false
+
+volumes:
+  data:
+    external: ${VOLUME_EXTERNAL:-false}
+    name: ${VOLUME_NAME:-arcane_data}
+    driver: ${VOLUME_DRIVER:-local}
+
+services:
+  # https://github.com/getarcaneapp/arcane — self-hosted Docker management UI (Manager).
+  # Needs the host Docker socket (read-write) for local Docker control and a persistent
+  # /app/data volume (SQLite). Arcane runs its startup as root and chowns /app/data to
+  # PUID/PGID before dropping privileges, so no manual volume chown is needed.
+  # ENCRYPTION_KEY is provided via the SOPS-managed env file and MUST be 32 bytes.
+  # First login: arcane / arcane-admin (forced change) — rotate immediately and enable 2FA.
+  # LAN-only: reached through the host's Traefik over the `apps` network; the published
+  # port below is bound to loopback for debugging only.
+  # Do NOT add `cap_drop`, `user:`, or `read_only: true`: the root startup phase needs
+  # CAP_CHOWN/CAP_SETUID/CAP_SETGID to chown /app/data and drop to PUID/PGID (verified
+  # against v2.11.0 — cap_drop:ALL makes it exit 1 with "chown ... operation not permitted").
+  arcane:
+    cgroup: host
+    container_name: ${CONTAINER_NAME:-arcane}
+    env_file:
+      - ${SOPS_ENV_FILE:-sops.env}
+    environment:
+      TZ: Europe/Vienna
+      APP_URL: ${APP_URL:-http://localhost:3552}
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
+      PUID: ${USER_ID:-1000}
+      PGID: ${GROUP_ID:-1000}
+    healthcheck:
+      test:
+        - CMD
+        - ./arcane
+        - health
+        - --timeout
+        - 2s
+      start_period: 15s
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    image: ghcr.io/getarcaneapp/manager:v2.11.0@sha256:a7005e4be1740ae7f3c0aa694ef825552271cb320b3906a98a5e8a642faa163a
+    mem_limit: 1g
+    pids_limit: 256
+    ports:
+      - ${WEB_HOST:-127.0.0.1}:${WEB_PORT:-3552}:3552
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges=true
+    volumes:
+      - data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - apps

--- a/docker/deploy/traefik/compose.yaml
+++ b/docker/deploy/traefik/compose.yaml
@@ -36,6 +36,8 @@ services:
       # Wildcard Setup
       - --entryPoints.websecure.http.tls.domains[0].main=techtales.ai
       - --entryPoints.websecure.http.tls.domains[0].sans=*.techtales.ai
+      # Arcane UI on bifrost (LAN-only) — requires the Cloudflare token to cover techtales.io
+      - --entryPoints.websecure.http.tls.domains[1].main=arcane.techtales.io
       # Docker Provider
       - --providers.docker=true
       - --providers.docker.exposedByDefault=false


### PR DESCRIPTION
## Changes
- `docker/deploy/arcane/compose.yaml`: Manager `v2.11.0` (digest-pinned), `/app/data`, docker.sock rw, `cgroup: host`, PUID/PGID 1000
- `docker/bifrost/arcane/`: include shim + Traefik `arcane.techtales.io` (websecure → 3552) + LAN DNS override
- `docker/deploy/traefik/compose.yaml`: ACME domain for `arcane.techtales.io`
- `docker/.doco-cd.bifrost.yaml`: register stack

## Verification
- `docker compose config` OK; clean start; healthcheck exit=0; root-owned named volume chowned to 1000:1000 (v2.11.0)

## Deploy notes
- LAN-only, no published host port (loopback debug only)
- Extend `CF_DNS_API_TOKEN` to the `techtales.io` zone before deploy
- `cap_drop`/`user:`/`read_only:` intentionally omitted — startup needs CAP_CHOWN/SETUID/SETGID