### PR TITLE
feat(renovate): track comfyui nvidia dated tags

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,15 @@
       automerge: false,
     },
     {
+      description: "ComfyUI Nvidia: date-suffixed OS+CUDA tags (ubuntu26_cuda13.3-YYYYMMDD)",
+      // Tag layout: <ubuntuNN>_cuda<X.Y>-<YYYYMMDD>, e.g. ubuntu26_cuda13.3-20260906.
+      // compatibility pins the OS+CUDA line so Renovate only bumps the date (and digest),
+      // never silently jumps to a different Ubuntu/CUDA line (which may need a newer driver).
+      matchDatasources: ["docker"],
+      matchPackageNames: ["mmartial/comfyui-nvidia-docker"],
+      versioning: "regex:^(?<compatibility>ubuntu[0-9]+_cuda[0-9.]+)-(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$",
+    },
+    {
       description: "add changelog for installer image (source is siderolabs/talos)",
       matchDepNames: ["ghcr.io/siderolabs/installer"],
       sourceUrl: "https://github.com/siderolabs/talos",

--- a/docker/deploy/comfyui/compose.yaml
+++ b/docker/deploy/comfyui/compose.yaml
@@ -16,10 +16,13 @@ volumes:
 
 services:
   comfyui-nvidia:
-    # Use latest tag which points to ubuntu24_cuda12.6.3-latest
-    # For Blackwell (RTX 50xx) GPUs, use: mmartial/comfyui-nvidia-docker:ubuntu24_cuda12.8-latest
-    # For GTX 10xx GPUs, use: mmartial/comfyui-nvidia-docker:ubuntu24_cuda12.6.3-latest
-    image: mmartial/comfyui-nvidia-docker:ubuntu24_cuda13.1-20260121@sha256:6e94003fd94766e315ae85398957737a1c835a0e2fe5629b447c372da7769eda
+    # Pinned to the Ubuntu 24.04 + CUDA 12.6.3 line for GTX 10xx GPUs:
+    #   mmartial/comfyui-nvidia-docker:ubuntu24_cuda12.6.3-latest
+    # Pinned to the Ubuntu 24.04 + CUDA 12.8 line for Blackwell (RTX 50xx) GPUs:
+    #   mmartial/comfyui-nvidia-docker:ubuntu24_cuda12.8-latest
+    # The trailing date is the upstream GitHub release. Renovate tracks new dates
+    # within the Ubuntu 26.04 + CUDA 13.3 line (see .github/renovate.json5).
+    image: mmartial/comfyui-nvidia-docker:ubuntu26_cuda13.3-20260805@sha256:1599aaff2e72a6f33faf10e0ec8f9ec704fc88f304ce7c30e0c17a97a19c986b
     container_name: comfyui-nvidia
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

- Add a Renovate `packageRules` entry using **regex versioning** so `mmartial/comfyui-nvidia-docker` date-suffixed tags (`ubuntuNN_cudaX.Y-YYYYMMDD`) are tracked. The `compatibility` capture group pins the OS+CUDA line, so Renovate only bumps the date (tag + digest together) and never silently jumps to a different Ubuntu/CUDA line.
- Switch the ComfyUI image to the `ubuntu26_cuda13.3` line, pinned to the **older** `20260805` tag so we can confirm Renovate opens the expected bump PR.

## Verification

Local Renovate lookup (`--platform=local --dry-run=lookup --enabled-managers=docker-compose`) detected exactly one update:

| | |
|---|---|
| current | `ubuntu26_cuda13.3-20260805` |
| new | `ubuntu26_cuda13.3-20260906` (minor) |
| new digest | `sha256:ef14e1837a078ba04690f6c0f1caaa1ea82f0300383b13d5316a9182c681cb8a` |
| branch | `renovate/mmartial-comfyui-nvidia-docker-2026.x` |

- `-latest` and `-dgx-*` tags do not match the regex and are ignored.
- `pre-commit` (prettier, yamllint) passes.

## Notes

- On merge, the `push` trigger on `.github/renovate.json5` runs the Renovate workflow, which should open the real date-bump PR — end-to-end confirmation.
- Do **not** use the moving `latest` tag: it currently resolves to `ubuntu24_cuda12.9-20260906` (a CUDA downgrade from the 13.1 line).
- CUDA 13.3 requires a recent NVIDIA driver; verify with `nvidia-smi` before `docker compose up`.
