### PR TITLE
feat(ollama): auto-pull models at container start

### DIFF
--- a/docker/.doco-cd.red.yaml
+++ b/docker/.doco-cd.red.yaml
@@ -19,6 +19,8 @@ env_files:
 ---
 name: ollama
 working_dir: docker/red/ollama
+env_files:
+  - .env
 ---
 name: node-exporter
 working_dir: docker/deploy/node-exporter

--- a/docker/bifrost/new-api/compose.yaml
+++ b/docker/bifrost/new-api/compose.yaml
@@ -16,7 +16,6 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.newapi.rule=Host(`techtales.ai`)"
       - "traefik.http.routers.newapi.entrypoints=websecure"
-      # Replace '8080' with the internal port your API application actually listens on
       - "traefik.http.services.newapi.loadbalancer.server.port=3000"
 
     dns:

--- a/docker/red/README.md
+++ b/docker/red/README.md
@@ -47,3 +47,4 @@ redirects to HTTPS, and the loopback ports are unreachable from another LAN host
 - Per-service layout follows the bifrost pattern: a real thin `compose.yaml` include shim plus the
   host's `.env`/`sops.env`. Symlinks are avoided (doco-cd redeploy-hash churn and path-escape
   false positives).
+- `ollama` auto-pulls the models in `OLLAMA_PULL_MODELS` (compose default `gemma3:1b gemma4:e2b`) on container start; repeat runs are no-ops.

--- a/docker/red/ollama/.env
+++ b/docker/red/ollama/.env
@@ -1,0 +1,4 @@
+TARGET=red
+# Space-separated models pulled on container start. Uncomment to override the compose
+# example default (gemma3:1b gemma4:e2b).
+# OLLAMA_PULL_MODELS=gemma3:1b gemma4:e2b

--- a/docker/red/ollama/compose.yaml
+++ b/docker/red/ollama/compose.yaml
@@ -19,6 +19,27 @@ services:
   ollama:
     networks:
       - apps
+    # Pre-script: start the server, wait until it accepts connections, pull the red models
+    # once (idempotent — fast no-op when already present), then stay in the foreground.
+    # Replaces a separate model-puller container.
+    environment:
+      # Space-separated models pulled on container start. Override per host by uncommenting
+      # OLLAMA_PULL_MODELS in docker/red/ollama/.env (compose example default below).
+      OLLAMA_PULL_MODELS: ${OLLAMA_PULL_MODELS:-gemma3:1b gemma4:e2b}
+    init: true
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        ollama serve &
+        pid=$$!
+        trap 'kill -TERM "$$pid" 2>/dev/null || true' TERM INT
+        until ollama list >/dev/null 2>&1; do sleep 1; done
+        for m in $${OLLAMA_PULL_MODELS:-}; do
+          echo "pulling $$m"
+          ollama pull "$$m" || echo "pull failed: $$m"
+        done
+        wait "$$pid"
     # Loopback-only: LAN access goes through Traefik TLS (ollama.tyriis.dev).
     ports: !override
       - "127.0.0.1:11434:11434"


### PR DESCRIPTION
- ollama pulls the models in `OLLAMA_PULL_MODELS` on container start (compose default `gemma3:1b gemma4:e2b`); idempotent
- merged into the existing ollama container (`/bin/sh -c` entrypoint, background `serve`, readiness wait, `init: true`)
- replaces a separate model-puller container
- red shim only; per-host override via `docker/red/ollama/.env` (doco-cd `env_files`)
- README note