### PR TITLE
feat(arcane): add edge agent on purple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ Thumbs.db
 !docker/deploy/**/red.env
 !docker/bifrost/**/.env
 !docker/bifrost/**/sops.env
+!docker/purple/**/.env
+!docker/purple/**/sops.env
 !docker/red/**/.env
 !docker/red/**/sops.env
 !docker/synology/**/.env

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -16,3 +16,6 @@ creation_rules:
   - path_regex: 'docker/bifrost/.*/sops\.env$'
     age: >-
       age16fdxndp7s8fmv0r9qa2f8ymwy7gca0eleev52f3qu9mwqvsqmaaqkvj5ja
+  - path_regex: 'docker/purple/.*/sops\.env$'
+    age: >-
+      age1rkck8xgdpzruefrulr68p86mx3dmkcm2l7eegah625t69qtw7vaqea4hs2

--- a/docker/.doco-cd.purple.yaml
+++ b/docker/.doco-cd.purple.yaml
@@ -4,3 +4,8 @@ working_dir: docker/deploy/ollama
 ---
 name: node-exporter
 working_dir: docker/deploy/node-exporter
+---
+name: arcane-agent
+working_dir: docker/purple/arcane-agent
+env_files:
+  - .env

--- a/docker/purple/arcane-agent/.env
+++ b/docker/purple/arcane-agent/.env
@@ -1,0 +1,4 @@
+TARGET=purple
+# Edge agent: connect outbound to the bifrost Manager through Traefik (LAN name, LE cert).
+MANAGER_API_URL=https://arcane.techtales.io
+EDGE_TRANSPORT=poll

--- a/docker/purple/arcane-agent/compose.yaml
+++ b/docker/purple/arcane-agent/compose.yaml
@@ -1,0 +1,11 @@
+---
+# Include shim — the actual service definition is shared: docker/deploy/arcane-agent/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file, the /app/data volume) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/arcane-agent/compose.yaml
+    project_directory: .

--- a/docker/purple/arcane-agent/sops.env
+++ b/docker/purple/arcane-agent/sops.env
@@ -1,0 +1,9 @@
+#ENC[AES256_GCM,data:eQUych92+VoSH6YhPB4zcjOEXD7PNG8FmzGi3lhGSyEoZctNOwJbKcm+/WZQ3lOWWkdB/kmkNKeSLFuDWyI477evFMozQJCK8PK8twWb9FdK,iv:yXcW8pgyEXjRgqzLkX25pnjxRwjfJ8l4pumuioIp/Vo=,tag:SObjwLz2kKl3UTig6a1o5g==,type:comment]
+#ENC[AES256_GCM,data:WiEC0luRfEE3P3L6bck34eqMwxvq+gm/W+rormGURqoYEsKgBdETMKb/l8hlEcHm4gd0yvqt1VlKrSnS4xQbBO9fz6zUgyHXi7mDds7IJInfX0nvXbM=,iv:91U0ilMDDRuVgD/wIggtfv/xQOx9on4ORGH51bO/uG4=,tag:OCl24QvNrppAsQAyLCXuCg==,type:comment]
+AGENT_TOKEN=ENC[AES256_GCM,data:qKkgE0W2JQeLBQ==,iv:PUE6Na1fIKyUgZ7VQdvGAKmDtBZZAvSpeNbwaFxK/mM=,tag:YC1Tk6h3No6FDaM/CeEwHw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEeHNYUjhJSzFQL0ZzblVp\nQnZoU3A1RnlOK2kwdTcyNnp6cW1oOHEwS1JBClJaQXVYclZDbU9jays2bmJnemZJ\nTHJYUHczQjBMeU1rd3NBU2lzZVJxa2cKLS0tIDF3TzBIMlBLVUFsOXBkU3gxU1A2\ndDdLRnAvQUJsNlJSazJYTURkcG14c2MKRcI0VrfNuKZwEpYgCaVCCagwC+6jdMvz\nTqXCsThjEUcZ/4ivfQXtNV6SORMa0zjj//cOCQODqdg+Y4JinN1tvQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1rkck8xgdpzruefrulr68p86mx3dmkcm2l7eegah625t69qtw7vaqea4hs2
+sops_lastmodified=2026-09-12T18:48:47Z
+sops_mac=ENC[AES256_GCM,data:FOyoUZCJQ3cbP14yU2wn4/w8wt0SIdRYM53w4hFrPFzC+gjhfURRfHKUqivpVmaQYwadD+ABf9qwKcTjjraHfRC9AbKRCs3NEm/2l7T8C0lxZEq1XQkPWPfV56ic1xrfi3oCcynCUhZ98RZNysENRaVCAtPKlofHrn7/O1KafzY=,iv:1GQ5egtEJxg8H/qaMW0CVuGNcMUjOaMyVXK3sRj6U/Q=,tag:9wy5FNcqG56rxKiWOuedaA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/docker/purple/arcane-agent/sops.env
+++ b/docker/purple/arcane-agent/sops.env
@@ -1,9 +1,9 @@
 #ENC[AES256_GCM,data:eQUych92+VoSH6YhPB4zcjOEXD7PNG8FmzGi3lhGSyEoZctNOwJbKcm+/WZQ3lOWWkdB/kmkNKeSLFuDWyI477evFMozQJCK8PK8twWb9FdK,iv:yXcW8pgyEXjRgqzLkX25pnjxRwjfJ8l4pumuioIp/Vo=,tag:SObjwLz2kKl3UTig6a1o5g==,type:comment]
 #ENC[AES256_GCM,data:WiEC0luRfEE3P3L6bck34eqMwxvq+gm/W+rormGURqoYEsKgBdETMKb/l8hlEcHm4gd0yvqt1VlKrSnS4xQbBO9fz6zUgyHXi7mDds7IJInfX0nvXbM=,iv:91U0ilMDDRuVgD/wIggtfv/xQOx9on4ORGH51bO/uG4=,tag:OCl24QvNrppAsQAyLCXuCg==,type:comment]
-AGENT_TOKEN=ENC[AES256_GCM,data:qKkgE0W2JQeLBQ==,iv:PUE6Na1fIKyUgZ7VQdvGAKmDtBZZAvSpeNbwaFxK/mM=,tag:YC1Tk6h3No6FDaM/CeEwHw==,type:str]
+AGENT_TOKEN=ENC[AES256_GCM,data:QUHEt2Ok0vg0r6dH+pEYpp6FijQ9xDFLIDbWwBGWS/hghwNwaYXpFjmET8FvYH5g8dc/hE62Ve9kqyiaD6Gm48MSi6E=,iv:3jA5f0XLfqv7qJzsz6FvVI5b/+SYhLhog2FePeaEVb0=,tag:rSrgTIUG5hzex7gyr8xt2w==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEeHNYUjhJSzFQL0ZzblVp\nQnZoU3A1RnlOK2kwdTcyNnp6cW1oOHEwS1JBClJaQXVYclZDbU9jays2bmJnemZJ\nTHJYUHczQjBMeU1rd3NBU2lzZVJxa2cKLS0tIDF3TzBIMlBLVUFsOXBkU3gxU1A2\ndDdLRnAvQUJsNlJSazJYTURkcG14c2MKRcI0VrfNuKZwEpYgCaVCCagwC+6jdMvz\nTqXCsThjEUcZ/4ivfQXtNV6SORMa0zjj//cOCQODqdg+Y4JinN1tvQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1rkck8xgdpzruefrulr68p86mx3dmkcm2l7eegah625t69qtw7vaqea4hs2
-sops_lastmodified=2026-09-12T18:48:47Z
-sops_mac=ENC[AES256_GCM,data:FOyoUZCJQ3cbP14yU2wn4/w8wt0SIdRYM53w4hFrPFzC+gjhfURRfHKUqivpVmaQYwadD+ABf9qwKcTjjraHfRC9AbKRCs3NEm/2l7T8C0lxZEq1XQkPWPfV56ic1xrfi3oCcynCUhZ98RZNysENRaVCAtPKlofHrn7/O1KafzY=,iv:1GQ5egtEJxg8H/qaMW0CVuGNcMUjOaMyVXK3sRj6U/Q=,tag:9wy5FNcqG56rxKiWOuedaA==,type:str]
+sops_lastmodified=2026-09-12T19:02:11Z
+sops_mac=ENC[AES256_GCM,data:lYVlaIAf68M632sqaWkhcsFDWRjGCpbOjxcjW8Py18plYRw1Ih1AUXfPKuobNvt6Pajoa9YqOPwZPFy9dJS50jZar9t5qG9yYcrLW5+1R/XtWzojfjw9gs4F2thknOYllTLktHr2gohSVwX8xWnH9z5CccKU2ihet3GT3I8Sfeg=,iv:qMAhmS7zmDQRet1bFTjwmPRg82oAeH7Mzd7+LHx21Xk=,tag:wuvv19nfdPImPByDNMOUDA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.3


### PR DESCRIPTION
- onboard purple as Arcane edge agent (edge/poll -> bifrost Manager)
- add docker/purple/arcane-agent include shim, .env, SOPS sops.env
- add docker/purple SOPS rule + un-ignore purple env files