### PR TITLE
feat(arcane): add edge agent on synology

### DIFF
--- a/docker/.doco-cd.synology.yaml
+++ b/docker/.doco-cd.synology.yaml
@@ -24,3 +24,8 @@ name: openssh-server
 working_dir: docker/synology/openssh-server
 env_files:
   - .env
+---
+name: arcane-agent
+working_dir: docker/synology/arcane-agent
+env_files:
+  - .env

--- a/docker/synology/arcane-agent/.env
+++ b/docker/synology/arcane-agent/.env
@@ -1,0 +1,4 @@
+TARGET=synology
+# Edge agent: connect outbound to the bifrost Manager through Traefik (LAN name, LE cert).
+MANAGER_API_URL=https://arcane.techtales.io
+EDGE_TRANSPORT=poll

--- a/docker/synology/arcane-agent/compose.yaml
+++ b/docker/synology/arcane-agent/compose.yaml
@@ -1,0 +1,11 @@
+---
+# Include shim — the actual service definition is shared: docker/deploy/arcane-agent/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file, the /app/data volume) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/arcane-agent/compose.yaml
+    project_directory: .

--- a/docker/synology/arcane-agent/sops.env
+++ b/docker/synology/arcane-agent/sops.env
@@ -1,0 +1,7 @@
+AGENT_TOKEN=ENC[AES256_GCM,data:BksfVgXBzAezcA==,iv:BYmWgkb+682Vo/pKmBS0fOxWAhrcAEQwlY/YjNVPMm4=,tag:/dL9ujae8yN5R+Eu14YMWQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJOHMwTGx0cU1mclhOVHh6\nYnh0ZUE2TGlGYmxiWHF3Y0NZQXFUdi9XREc0CkhuZ0tNT242OU5keGhmNTJqdHV3\nUXZsQUcxQXc5YWljY3pSeityNXE4NDgKLS0tIDNzdWRYUWF4bXZWbGZ4ZG91cnBS\nV1FUTmZieFFob1RPODhybUhObmpaL0UKjhUbEzLuuQfTS11v5XeN4ivyeef594XD\n4r/P+vhJ9YiUmO9+9m/2tRC24+5A23YwZ8wya0UzF8qAwNIoeDe58Q==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1tcjhmd54y4nx9mpwld5fu0laav06wwjscvq4adqfquxtj4fg7a7q2s95sc
+sops_lastmodified=2026-09-12T21:34:15Z
+sops_mac=ENC[AES256_GCM,data:qtMVAj8a//JMCZ7jt+IikP2K6D8iE5YSoAwMin7fUYqURDDMoWCwnjrLgGmtUtIfBMyVZmKP5FSHhdOYqwyJ8bLYOnF1FAeq7TU2zvLHp5tYi5AYOJpuhvr9RZ4VdItNoSUUb9R9RojifPE3p7chZKazmGiZOSTxaDO1VVbHYMg=,iv:vBMyCjeclVw5URGrmKnQ27qqpDXyQKksK0CHWm3CRDA=,tag:IgxnbPsoNHyU73o+BOe9TQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/docker/synology/arcane-agent/sops.env
+++ b/docker/synology/arcane-agent/sops.env
@@ -1,7 +1,7 @@
-AGENT_TOKEN=ENC[AES256_GCM,data:BksfVgXBzAezcA==,iv:BYmWgkb+682Vo/pKmBS0fOxWAhrcAEQwlY/YjNVPMm4=,tag:/dL9ujae8yN5R+Eu14YMWQ==,type:str]
+AGENT_TOKEN=ENC[AES256_GCM,data:6ivXDuwqe91fcMul3IB+eRdk0PLxPsKefg0ux778lRV3fpP0f8rP2nwvNe+Km2ORca16nBAFYt25nBnLz95cLeJVIJg=,iv:xTb70+SiSYJ8p+D7EhiiISxgfBF8d2nS8UpLewDLDZE=,tag:2SkiqcvS1EVlhD7ASgHzhA==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJOHMwTGx0cU1mclhOVHh6\nYnh0ZUE2TGlGYmxiWHF3Y0NZQXFUdi9XREc0CkhuZ0tNT242OU5keGhmNTJqdHV3\nUXZsQUcxQXc5YWljY3pSeityNXE4NDgKLS0tIDNzdWRYUWF4bXZWbGZ4ZG91cnBS\nV1FUTmZieFFob1RPODhybUhObmpaL0UKjhUbEzLuuQfTS11v5XeN4ivyeef594XD\n4r/P+vhJ9YiUmO9+9m/2tRC24+5A23YwZ8wya0UzF8qAwNIoeDe58Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1tcjhmd54y4nx9mpwld5fu0laav06wwjscvq4adqfquxtj4fg7a7q2s95sc
-sops_lastmodified=2026-09-12T21:34:15Z
-sops_mac=ENC[AES256_GCM,data:qtMVAj8a//JMCZ7jt+IikP2K6D8iE5YSoAwMin7fUYqURDDMoWCwnjrLgGmtUtIfBMyVZmKP5FSHhdOYqwyJ8bLYOnF1FAeq7TU2zvLHp5tYi5AYOJpuhvr9RZ4VdItNoSUUb9R9RojifPE3p7chZKazmGiZOSTxaDO1VVbHYMg=,iv:vBMyCjeclVw5URGrmKnQ27qqpDXyQKksK0CHWm3CRDA=,tag:IgxnbPsoNHyU73o+BOe9TQ==,type:str]
+sops_lastmodified=2026-09-12T21:50:38Z
+sops_mac=ENC[AES256_GCM,data:g/qSG1boiYkRSnsbUTZEgL7fH22Ke5M2ihSnsQasDfBGmm+opKDJCiGMWohhBcqWXyuwWrFLUtv+s7KTV1LXSMj/VBlGE75aCUCBy9r+MpE/pjvGf6gZ0UesTr3q3HI0jnBSr/j/0XBG7/gmM0AOxVDIuThmOSti30VU1T+5Nzs=,iv:NHeb8RmER6EKNq2Z+scjzEFAoQO9T4kFJGofqKHNWFQ=,tag:+AefZ2PXQ+ZzWGF4FOd1aA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.3


### PR DESCRIPTION
- Add `docker/synology/arcane-agent/` (compose include shim, `.env`, SOPS `sops.env`)
- Append `arcane-agent` stanza to `docker/.doco-cd.synology.yaml`
- `AGENT_TOKEN=REPLACE_ME` — re-encrypt with real token before deploy