### PR TITLE
refactor(docker): replace legacy compose symlinks with include shims

### DIFF
--- a/docker/deploy/olah/README.md
+++ b/docker/deploy/olah/README.md
@@ -7,7 +7,7 @@ See ADR 0010 (this service) and ADR 0004 (TrueNAS + doco-cd lane).
 ## Layout
 
 - `docker/deploy/olah/compose.yaml`: shared compose definition (olah CLI flags + security hardening; no env_file needed)
-- `docker/truenas/olah/compose.yaml`: symlink to the shared compose (repo convention, same as every other instance)
+- `docker/truenas/olah/compose.yaml`: real include shim into the shared compose (`project_directory: .`)
 - `docker/truenas/olah/.env`: target identifier, host cache dataset path, run-as uid/gid
 - `docker/.doco-cd.truenas.yaml`: doco-cd registration for the truenas target
 

--- a/docker/synology/busybox-enc/compose.yaml
+++ b/docker/synology/busybox-enc/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/busybox-enc/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/busybox-enc/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/busybox-enc/compose.yaml
+    project_directory: .

--- a/docker/synology/minio/compose.yaml
+++ b/docker/synology/minio/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/minio/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/minio/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file, ${DATA_PATH:-./data} bind) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/minio/compose.yaml
+    project_directory: .

--- a/docker/synology/node-exporter/compose.yaml
+++ b/docker/synology/node-exporter/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/node-exporter/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/node-exporter/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so the host .env is loaded for ${...} substitution,
+# against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/node-exporter/compose.yaml
+    project_directory: .

--- a/docker/synology/openssh-server/compose.yaml
+++ b/docker/synology/openssh-server/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/openssh-server/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/openssh-server/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (host .env, ${DATA_PATH} bind) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/openssh-server/compose.yaml
+    project_directory: .

--- a/docker/synology/tailscale/compose.yaml
+++ b/docker/synology/tailscale/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/tailscale/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/tailscale/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (env_file, ${DATA_PATH} bind) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/tailscale/compose.yaml
+    project_directory: .

--- a/docker/truenas/olah/compose.yaml
+++ b/docker/truenas/olah/compose.yaml
@@ -1,1 +1,11 @@
-../../deploy/olah/compose.yaml
+---
+# Include shim — the actual service definition is shared: docker/deploy/olah/compose.yaml.
+# doco-cd runs compose in working_dir and hard-fails ("no compose files found") unless a
+# compose file is resolvable there; this real file provides it. Symlinks are deliberately
+# avoided (redeploy-hash churn, doco-cd #954; path-escape false positives, v0.74
+# regressions #1142/#1086/#1152).
+# project_directory: . is REQUIRED so relative paths inside the shared compose
+# (host .env, ${DATA_PATH:-./data} bind) resolve against this host directory, not the deploy dir.
+include:
+  - path: ../../deploy/olah/compose.yaml
+    project_directory: .


### PR DESCRIPTION
- synology: busybox-enc, minio, node-exporter, tailscale, openssh-server
- truenas: olah (+ README)
- resolved `docker compose config` verified byte-identical old vs new
- no symlinks remaining under `docker/`

Note: synology `tailscale` is the remote-access lifeline — verify doco-cd/Compose `include:` support on the host before merge.