### PR TITLE
feat(red): route jupyter via traefik, drop host ports

### DIFF
--- a/docker/deploy/unsloth/README.md
+++ b/docker/deploy/unsloth/README.md
@@ -11,8 +11,12 @@ Unsloth — LLM fine-tuning toolkit with Unsloth Studio (web UI + OpenAI/Anthrop
 
 ## Ports
 
-- `8000`: Unsloth Studio UI + API — bound on all interfaces (LAN).
-- `8888`: Jupyter Lab — bound to `127.0.0.1` only.
+- `8000`: Unsloth Studio UI + API — the shared-compose baseline binds it on all interfaces (LAN).
+- `8888`: Jupyter Lab — the shared-compose baseline binds it to `127.0.0.1` only.
+
+The red shim (`docker/red/unsloth/compose.yaml`) resets `ports` to none, so the host publishes no
+ports. Traefik fronts Studio at `unsloth.tyriis.dev` (`:8000`) and Jupyter at `jupyter.tyriis.dev`
+(`:8888`) over the shared `apps` network.
 
 ## Secrets
 

--- a/docker/red/README.md
+++ b/docker/red/README.md
@@ -6,20 +6,21 @@ LLM/image tooling and an Arcane edge agent. GitOps via doco-cd with `TARGET=red`
 
 ## Services
 
-| Service                 | Hostname             | Backend (container port)      | Direct host port  |
-| ----------------------- | -------------------- | ----------------------------- | ----------------- |
-| traefik                 | —                    | —                             | `80`/`443` (LAN)  |
-| unsloth (Studio UI/API) | `unsloth.tyriis.dev` | `unsloth:8000`                | `127.0.0.1:8000`  |
-| unsloth Jupyter         | internal             | `unsloth:8888`                | `127.0.0.1:8888`  |
-| comfyui                 | `comfyui.tyriis.dev` | `comfyui-nvidia:8188`         | `127.0.0.1:8188`  |
-| comfyui-gallery         | `gallery.tyriis.dev` | `comfyui-gallery:8189`        | `127.0.0.1:8189`  |
-| ollama                  | `ollama.tyriis.dev`  | `ollama:11434`                | `127.0.0.1:11434` |
-| node-exporter           | not proxied          | host net `:9100`              | `:9100`           |
-| smartctl-exporter       | not proxied          | `:9633`                       | `:9633`           |
-| busybox-enc             | —                    | SOPS decrypt smoke test       | —                 |
-| arcane-agent            | —                    | outbound edge poll to bifrost | —                 |
+| Service                 | Hostname             | Backend (container port)      | Direct host port |
+| ----------------------- | -------------------- | ----------------------------- | ---------------- |
+| traefik                 | —                    | —                             | `80`/`443` (LAN) |
+| unsloth (Studio UI/API) | `unsloth.tyriis.dev` | `unsloth:8000`                | —                |
+| unsloth Jupyter         | `jupyter.tyriis.dev` | `unsloth:8888`                | —                |
+| comfyui                 | `comfyui.tyriis.dev` | `comfyui-nvidia:8188`         | `127.0.0.1:8188` |
+| comfyui-gallery         | `gallery.tyriis.dev` | `comfyui-gallery:8189`        | `127.0.0.1:8189` |
+| ollama                  | `ollama.tyriis.dev`  | `ollama:11434`                | —                |
+| node-exporter           | not proxied          | host net `:9100`              | `:9100`          |
+| smartctl-exporter       | not proxied          | `:9633`                       | `:9633`          |
+| busybox-enc             | —                    | SOPS decrypt smoke test       | —                |
+| arcane-agent            | —                    | outbound edge poll to bifrost | —                |
 
-Traefik terminates TLS for the four proxied services and redirects HTTP to HTTPS. It obtains a
+Traefik terminates TLS for the five proxied services (Studio, Jupyter, `comfyui`, `gallery`,
+`ollama`) and redirects HTTP to HTTPS. It obtains a
 single wildcard certificate (`tyriis.dev` + `*.tyriis.dev`) from Let's Encrypt via the Cloudflare
 DNS-01 challenge. The shared Traefik definition lives in `docker/deploy/traefik/compose.yaml`; the
 red instance is an include shim that overrides only the static `command:` (see
@@ -31,19 +32,21 @@ are scraped directly on the LAN.
 
 ## First deploy
 
-1. Create UniFi (UDM SE) local DNS A records → `192.168.1.22` for `unsloth`, `comfyui`, `gallery`, `ollama` `.tyriis.dev`.
+1. Create UniFi (UDM SE) local DNS A records → `192.168.1.22` for `unsloth`, `jupyter`, `comfyui`, `gallery`, `ollama` `.tyriis.dev`.
 2. Put the real Cloudflare token (Zone:DNS:Edit on the `tyriis.dev` zone) into the encrypted file: `sops docker/red/traefik/sops.env`, replace `CF_DNS_API_TOKEN=REPLACE_ME`.
 3. Confirm `ACME_EMAIL` in `docker/red/traefik/.env`.
 4. Ensure red's doco-cd has the red age key (`SOPS_AGE_KEY_FILE`) so `sops.env` decrypts.
 5. Let doco-cd apply `docker/.doco-cd.red.yaml` (Traefik first).
 
 Verify: `curl -sI https://unsloth.tyriis.dev` serves a valid `*.tyriis.dev` certificate, HTTP
-redirects to HTTPS, and the loopback ports are unreachable from another LAN host.
+redirects to HTTPS, and `ollama`/`unsloth` no longer publish host ports (Traefik reaches containers
+over the `apps` network). `comfyui`/`gallery` still bind loopback for now.
 
 ## Notes
 
 - TLS provides transport security, not authentication. `ollama`, `comfyui`, and `gallery` have no
   login of their own; they are LAN-only via private-IP DNS. Do not port-forward them.
+- Jupyter is protected by `JUPYTER_PASSWORD`; the other proxied services remain unauthenticated.
 - Per-service layout follows the bifrost pattern: a real thin `compose.yaml` include shim plus the
   host's `.env`/`sops.env`. Symlinks are avoided (doco-cd redeploy-hash churn and path-escape
   false positives).

--- a/docker/red/ollama/compose.yaml
+++ b/docker/red/ollama/compose.yaml
@@ -40,9 +40,9 @@ services:
           ollama pull "$$m" || echo "pull failed: $$m"
         done
         wait "$$pid"
-    # Loopback-only: LAN access goes through Traefik TLS (ollama.tyriis.dev).
-    ports: !override
-      - "127.0.0.1:11434:11434"
+    # No host ports: Traefik reaches ollama:11434 over the shared `apps` network
+    # (https://ollama.tyriis.dev). `!reset` drops the ports inherited from the include.
+    ports: !reset []
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ollama.rule=Host(`ollama.tyriis.dev`)"

--- a/docker/red/unsloth/compose.yaml
+++ b/docker/red/unsloth/compose.yaml
@@ -19,12 +19,14 @@ services:
   unsloth:
     networks:
       - apps
-    # Loopback-only: LAN access goes through Traefik TLS (unsloth.tyriis.dev).
-    ports: !override
-      - "127.0.0.1:8000:8000"
-      - "127.0.0.1:8888:8888"
+    # No host ports: Traefik reaches Studio (:8000) and Jupyter (:8888) over the
+    # shared `apps` network. `!reset` drops the ports inherited from the include.
+    ports: !reset []
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.unsloth.rule=Host(`unsloth.tyriis.dev`)"
       - "traefik.http.routers.unsloth.entrypoints=websecure"
       - "traefik.http.services.unsloth.loadbalancer.server.port=8000"
+      - "traefik.http.routers.jupyter.rule=Host(`jupyter.tyriis.dev`)"
+      - "traefik.http.routers.jupyter.entrypoints=websecure"
+      - "traefik.http.services.jupyter.loadbalancer.server.port=8888"

--- a/docs/superpowers/plans/2026-09-12-red-traefik-tls-termination.md
+++ b/docs/superpowers/plans/2026-09-12-red-traefik-tls-termination.md
@@ -1,5 +1,9 @@
 # red Traefik TLS Termination Implementation Plan
 
+> **Historical note (2026-09-13):** This plan is retained as a historical record. The loopback host
+> ports described below were later removed and Jupyter now routes at `jupyter.tyriis.dev`, per the
+> amended design spec (`docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md`).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Terminate TLS for red's `unsloth`, `comfyui`, `gallery`, and `ollama` services with a Traefik instance on `tyriis.dev`, without touching the working bifrost Traefik.

--- a/docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md
+++ b/docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md
@@ -2,6 +2,9 @@
 
 - **Status:** Accepted
 - **Date:** 2026-09-12
+- **Amended:** 2026-09-13 — `ollama` and `unsloth` now publish no host ports (`ports: !reset []`)
+  and Jupyter is additionally routed at `jupyter.tyriis.dev` → `unsloth:8888`; `comfyui`/`gallery`
+  still bind loopback pending a follow-up.
 - **Scope:** `docker/red/**`, `docker/deploy/node-exporter/compose.yaml`, `docker/.doco-cd.red.yaml`
 - **Supersedes:** the "Reverse proxy or TLS termination" non-goal in `docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md`
 
@@ -28,11 +31,11 @@ should get the same treatment for the domain `tyriis.dev`.
 ## Goals
 
 - TLS termination (Let's Encrypt, HTTP→HTTPS redirect) in front of red's browser/HTTP workloads:
-  `unsloth`, `comfyui`, `gallery`, `ollama`.
+  `unsloth` (Studio), Jupyter, `comfyui`, `gallery`, `ollama`.
 - Hostnames under `tyriis.dev`, one wildcard certificate.
 - Reuse the existing shared Traefik definition without changing the working `bifrost` instance.
 - Follow the established `docker/deploy/<svc>` shared-compose + per-host include-shim convention.
-- Restrict direct plaintext host ports of the now-proxied services to loopback.
+- Publish no host ports for `ollama` and `unsloth`; keep LAN access behind Traefik (TLS).
 
 ## Non-goals
 
@@ -44,7 +47,6 @@ should get the same treatment for the domain `tyriis.dev`.
 - No authentication/authorization middleware. Traefik provides TLS, not auth.
 - No public exposure (LAN-only, private-IP DNS records).
 - No changes to `docker/deploy/traefik/compose.yaml` (bifrost-safe).
-- Jupyter (`:8888`) stays internal (loopback only), not published.
 
 ## Decisions
 
@@ -74,12 +76,15 @@ backends through Docker-provider labels (`traefik.enable`, `traefik.http.routers
 `traefik.http.services.*.loadbalancer.server.port`), exactly as bifrost does. `apps` is
 host-local (`name: apps`, `external: false`), so red's is independent of bifrost's.
 
-### D4 — Direct ports restricted to loopback
+### D4 — `ollama` and `unsloth` publish no host ports; Jupyter routed
 
-Proxied services override their published ports to `127.0.0.1` (`!override` on the list). Traefik
-reaches containers over `apps`, so host ports are only for local debugging. This applies to
-`unsloth` (`8000`, `8888`), `comfyui-nvidia` (`8188`), `comfyui-gallery` (`8189`), `ollama`
-(`11434`). Metrics services are excluded (non-goal).
+`docker/red/ollama` (`11434`) and `docker/red/unsloth` (Studio `8000`, Jupyter `8888`) reset their
+published ports to none (`ports: !reset []`), dropping the ports inherited from the shared include.
+Traefik reaches them purely over the `apps` network, so the red host publishes no plaintext ports
+for these two services. Jupyter is additionally routed at `jupyter.tyriis.dev` → `unsloth:8888`
+(router/service `jupyter`), alongside Studio at `unsloth.tyriis.dev` → `unsloth:8000`.
+`comfyui-nvidia` (`8188`) and `comfyui-gallery` (`8189`) still override their ports to loopback
+(`!override`); removing those is a follow-up. Metrics services are excluded (non-goal).
 
 ### D5 — smartctl-exporter image change (independent)
 
@@ -93,6 +98,7 @@ Shared across hosts; behaviour unchanged apart from the image.
 LAN client ──TLS──> red:443 (Traefik, `apps`)
                       │  Host(...) rules via Docker labels
                       ├── unsloth.tyriis.dev   → unsloth:8000        (apps)
+                      ├── jupyter.tyriis.dev   → unsloth:8888        (apps)
                       ├── comfyui.tyriis.dev   → comfyui-nvidia:8188 (apps)
                       ├── gallery.tyriis.dev   → comfyui-gallery:8189(apps)
                       └── ollama.tyriis.dev    → ollama:11434        (apps)
@@ -105,6 +111,7 @@ node-exporter (host net 9100) / smartctl-exporter (9633)  ← unchanged, not pro
 | Hostname | Backend (apps) | Container port | Router | Service |
 | --- | --- | --- | --- | --- |
 | `unsloth.tyriis.dev` | `unsloth` | `8000` | `unsloth` | `unsloth` |
+| `jupyter.tyriis.dev` | `unsloth` | `8888` | `jupyter` | `jupyter` |
 | `comfyui.tyriis.dev` | `comfyui-nvidia` | `8188` | `comfyui` | `comfyui` |
 | `gallery.tyriis.dev` | `comfyui-gallery` | `8189` | `gallery` | `gallery` |
 | `ollama.tyriis.dev` | `ollama` | `11434` | `ollama` | `ollama` |
@@ -125,13 +132,14 @@ the SOPS-encrypted `docker/red/traefik/sops.env`, decrypted by doco-cd at deploy
 - `docker/red/traefik/compose.yaml` — include shim + `command:` override (wildcard `tyriis.dev`).
 - `docker/red/traefik/.env` — `TARGET=red`, `TLS_DOMAIN=tyriis.dev`, `ACME_EMAIL=…`.
 - `docker/red/traefik/sops.env` — SOPS-encrypted `CF_DNS_API_TOKEN` (red age key).
-- `docker/red/ollama/compose.yaml` — shim: `apps` + labels + loopback port.
+- `docker/red/ollama/compose.yaml` — shim: `apps` + labels + no host ports.
 - `docker/red/comfyui/compose.yaml` — shim: `apps` + labels + loopback ports for both web UIs.
 - `docker/red/README.md` — host documentation, routing table, DNS runbook, first-deploy notes.
 
 **Modified**
 
-- `docker/red/unsloth/compose.yaml` — add `apps`, labels, loopback ports.
+- `docker/red/unsloth/compose.yaml` — add `apps`, labels, the `jupyter` router; reset `ports` to
+  none.
 - `docker/.doco-cd.red.yaml` — add `traefik` workload (first), repoint `ollama`/`comfyui` to
   `docker/red/*`; `node-exporter` stays at `docker/deploy/node-exporter`.
 - `docker/deploy/node-exporter/compose.yaml` — smartctl-exporter image (D5).
@@ -152,15 +160,16 @@ the SOPS-encrypted `docker/red/traefik/sops.env`, decrypted by doco-cd at deploy
 
 ## Verification
 
-- `docker compose config` succeeds for `docker/red/traefik`, `docker/red/unsloth`,
-  `docker/red/ollama`, `docker/red/comfyui` and shows the expected command, labels, `apps`
-  membership, and loopback ports.
+- `docker compose config` on `docker/red/ollama` and `docker/red/unsloth` emits no `ports` for the
+  service; it shows the expected labels, `apps` membership, and (for unsloth) both the `unsloth`
+  and `jupyter` routers/services.
 - `docker compose config` on `docker/deploy/traefik` is unchanged (no diff).
 - `pre-commit run --files <changed files>` passes (yamllint, prettier, check-symlinks, etc.).
 - `sops --decrypt docker/red/traefik/sops.env` prints `CF_DNS_API_TOKEN` (operator, with red key).
-- Post-deploy (operator): `curl -sI https://unsloth.tyriis.dev` returns a valid LE certificate for
-  `*.tyriis.dev`; HTTP redirects to HTTPS; loopback direct ports are not reachable from another
-  LAN host.
+- Post-deploy (operator): `curl -sI https://unsloth.tyriis.dev` and
+  `https://jupyter.tyriis.dev` return a valid LE certificate for `*.tyriis.dev`; HTTP redirects to
+  HTTPS; `https://jupyter.tyriis.dev` loads JupyterLab (kernel/WebSocket works); no host ports are
+  published on the LAN.
 
 ## Risks
 
@@ -173,3 +182,7 @@ the SOPS-encrypted `docker/red/traefik/sops.env`, decrypted by doco-cd at deploy
   `docker/deploy/traefik/compose.yaml` guards this.
 - **TLS ≠ auth:** `ollama`, `comfyui`, `gallery` have no authentication; they remain LAN-only via
   private-IP DNS.
+- **Jupyter Host/remote access:** the May image's entrypoint came from a now-private repo, so its
+  default Jupyter config is not fully auditable. If Jupyter rejects the proxied `Host` header
+  (`jupyter.tyriis.dev`), the fallback is to mount a `jupyter_lab_config.py` setting
+  `allow_remote_access`/`local_hostnames`.


### PR DESCRIPTION
## Summary
- Expose Unsloth's Jupyter Lab via Traefik TLS at `jupyter.tyriis.dev` (`unsloth:8888`).
- Remove all host-published ports on red for `ollama` (`11434`) and `unsloth` (Studio `8000`, Jupyter `8888`); Traefik now reaches them purely over the `apps` network.
- Amend the red Traefik TLS design spec and the red/unsloth READMEs; add a historical note to the implementation plan.

## Changes
- `docker/red/ollama/compose.yaml`: loopback port -> `ports: !reset []`.
- `docker/red/unsloth/compose.yaml`: loopback ports -> `ports: !reset []`; add `jupyter` router/service (`Host(jupyter.tyriis.dev)`, port `8888`), keep the `unsloth` router (`:8000`).
- Shared composes untouched (`docker/deploy/ollama` is still consumed directly by purple).

## Verification
- `docker compose -f docker/red/ollama/compose.yaml config` and `.../unsloth/config`: no published `ports:`; unsloth shows both `unsloth` and `jupyter` routers/services.
- `pre-commit run --files <changed>` passes.

## Out of scope / follow-ups (operator)
- `comfyui`/`gallery` still bind `127.0.0.1` (documented as a follow-up).
- UniFi local DNS A record `jupyter.tyriis.dev` -> `192.168.1.22` required; the `*.tyriis.dev` wildcard cert covers it.
- The May image's entrypoint came from a now-private repo; if Jupyter rejects the proxied Host header, fall back to a mounted `jupyter_lab_config.py`.