### PR TITLE
feat(ollama): gate red api with bearer key

### DIFF
--- a/docker/red/README.md
+++ b/docker/red/README.md
@@ -42,8 +42,7 @@ are scraped directly on the LAN.
 2. Put the real Cloudflare token (Zone:DNS:Edit on the `tyriis.dev` zone) into the encrypted file: `sops docker/red/traefik/sops.env`, replace `CF_DNS_API_TOKEN=REPLACE_ME`.
 3. Confirm `ACME_EMAIL` in `docker/red/traefik/.env`.
 4. Ensure red's doco-cd has the red age key (`SOPS_AGE_KEY_FILE`) so `sops.env` decrypts.
-5. Ensure `docker/red/ollama/sops.env` holds the encrypted `OLLAMA_API_KEY` (committed encrypted;
-   rotate with `sops docker/red/ollama/sops.env`).
+5. Ensure `docker/red/ollama/sops.env` holds the encrypted `OLLAMA_API_KEY` (committed encrypted; rotate with `sops docker/red/ollama/sops.env`).
 6. Let doco-cd apply `docker/.doco-cd.red.yaml` (Traefik first).
 
 Verify: `curl -sI https://unsloth.tyriis.dev` serves a valid `*.tyriis.dev` certificate, HTTP

--- a/docker/red/README.md
+++ b/docker/red/README.md
@@ -6,18 +6,18 @@ LLM/image tooling and an Arcane edge agent. GitOps via doco-cd with `TARGET=red`
 
 ## Services
 
-| Service                 | Hostname             | Backend (container port)      | Direct host port |
-| ----------------------- | -------------------- | ----------------------------- | ---------------- |
-| traefik                 | —                    | —                             | `80`/`443` (LAN) |
-| unsloth (Studio UI/API) | `unsloth.tyriis.dev` | `unsloth:8000`                | —                |
-| unsloth Jupyter         | `jupyter.tyriis.dev` | `unsloth:8888`                | —                |
-| comfyui                 | `comfyui.tyriis.dev` | `comfyui-nvidia:8188`         | —                |
-| comfyui-gallery         | `gallery.tyriis.dev` | `comfyui-gallery:8189`        | —                |
-| ollama                  | `ollama.tyriis.dev`  | `ollama:11434`                | —                |
-| node-exporter           | not proxied          | host net `:9100`              | `:9100`          |
-| smartctl-exporter       | not proxied          | `:9633`                       | `:9633`          |
-| busybox-enc             | —                    | SOPS decrypt smoke test       | —                |
-| arcane-agent            | —                    | outbound edge poll to bifrost | —                |
+| Service                 | Hostname             | Backend (container port)            | Direct host port |
+| ----------------------- | -------------------- | ----------------------------------- | ---------------- |
+| traefik                 | —                    | —                                   | `80`/`443` (LAN) |
+| unsloth (Studio UI/API) | `unsloth.tyriis.dev` | `unsloth:8000`                      | —                |
+| unsloth Jupyter         | `jupyter.tyriis.dev` | `unsloth:8888`                      | —                |
+| comfyui                 | `comfyui.tyriis.dev` | `comfyui-nvidia:8188`               | —                |
+| comfyui-gallery         | `gallery.tyriis.dev` | `comfyui-gallery:8189`              | —                |
+| ollama (gated)          | `ollama.tyriis.dev`  | `ollama-auth:8080` → `ollama:11434` | —                |
+| node-exporter           | not proxied          | host net `:9100`                    | `:9100`          |
+| smartctl-exporter       | not proxied          | `:9633`                             | `:9633`          |
+| busybox-enc             | —                    | SOPS decrypt smoke test             | —                |
+| arcane-agent            | —                    | outbound edge poll to bifrost       | —                |
 
 Traefik terminates TLS for the five proxied services (Studio, Jupyter, `comfyui`, `gallery`,
 `ollama`) and redirects HTTP to HTTPS. It obtains a
@@ -25,6 +25,12 @@ single wildcard certificate (`tyriis.dev` + `*.tyriis.dev`) from Let's Encrypt v
 DNS-01 challenge. The shared Traefik definition lives in `docker/deploy/traefik/compose.yaml`; the
 red instance is an include shim that overrides only the static `command:` (see
 `docker/red/traefik/compose.yaml`).
+
+`ollama.tyriis.dev` is additionally gated by `ollama-auth` — a digest-pinned `caddy:2` container
+that requires an OpenAI-style `Authorization: Bearer <key>` header before proxying to
+`ollama:11434` (OSS Traefik has no native bearer/API-key middleware). The key exists only in the
+SOPS-encrypted `docker/red/ollama/sops.env`; no plaintext key is committed or placed in Compose
+labels.
 
 **Metrics are intentionally not proxied.** `node-exporter` needs `network_mode: host` for correct
 `netdev`/`netstat`/`sockstat` metrics (`/proc/net` is netns-scoped), so it and `smartctl-exporter`
@@ -36,17 +42,30 @@ are scraped directly on the LAN.
 2. Put the real Cloudflare token (Zone:DNS:Edit on the `tyriis.dev` zone) into the encrypted file: `sops docker/red/traefik/sops.env`, replace `CF_DNS_API_TOKEN=REPLACE_ME`.
 3. Confirm `ACME_EMAIL` in `docker/red/traefik/.env`.
 4. Ensure red's doco-cd has the red age key (`SOPS_AGE_KEY_FILE`) so `sops.env` decrypts.
-5. Let doco-cd apply `docker/.doco-cd.red.yaml` (Traefik first).
+5. Ensure `docker/red/ollama/sops.env` holds the encrypted `OLLAMA_API_KEY` (committed encrypted;
+   rotate with `sops docker/red/ollama/sops.env`).
+6. Let doco-cd apply `docker/.doco-cd.red.yaml` (Traefik first).
 
 Verify: `curl -sI https://unsloth.tyriis.dev` serves a valid `*.tyriis.dev` certificate, HTTP
 redirects to HTTPS, and no proxied service publishes host ports (Traefik reaches all containers
-over the `apps` network).
+over the `apps` network). `curl https://ollama.tyriis.dev/api/tags` returns `401` without the key.
+
+## Ollama API key
+
+- Clients must send `Authorization: Bearer <OLLAMA_API_KEY>`:
+  - OpenAI-compatible: `base_url=https://ollama.tyriis.dev/v1`, `api_key=<key>`, e.g. `curl https://ollama.tyriis.dev/v1/models -H "Authorization: Bearer $KEY"`.
+  - Ollama Python SDK: set `OLLAMA_API_KEY` (sent as a bearer header).
+  - Open WebUI: add the connection with `OLLAMA_API_CONFIGS[].key`.
+- The official `ollama` CLI has no way to send an arbitrary bearer header; point it at a keyless
+  local endpoint instead.
+- Rotate: `sops docker/red/ollama/sops.env`, then let doco-cd redeploy the `ollama` stack.
 
 ## Notes
 
-- TLS provides transport security, not authentication. `ollama`, `comfyui`, and `gallery` have no
-  login of their own; they are LAN-only via private-IP DNS. Do not port-forward them.
-- Jupyter is protected by `JUPYTER_PASSWORD`; the other proxied services remain unauthenticated.
+- TLS provides transport security. `comfyui` and `gallery` have no login of their own; they are
+  LAN-only via private-IP DNS. Do not port-forward them.
+- Jupyter is protected by `JUPYTER_PASSWORD`; Studio, `comfyui`, and `gallery` remain
+  unauthenticated beyond the LAN boundary.
 - Per-service layout follows the bifrost pattern: a real thin `compose.yaml` include shim plus the
   host's `.env`/`sops.env`. Symlinks are avoided (doco-cd redeploy-hash churn and path-escape
   false positives).

--- a/docker/red/ollama/Caddyfile
+++ b/docker/red/ollama/Caddyfile
@@ -1,0 +1,13 @@
+# OpenAI-style `Authorization: Bearer` gate for red's Ollama.
+# Caddy is a transparent pass-through: Ollama itself serves the OpenAI-compatible /v1 API;
+# this only rejects requests that do not present the shared key.
+# The key is injected at container start from the env (doco-cd decrypts
+# docker/red/ollama/sops.env -> OLLAMA_API_KEY); it is never committed in plaintext.
+# The `:__unset__` default makes the gate fail CLOSED if the env var is ever missing
+# (no client can present "Bearer __unset__").
+:8080 {
+    @denied not header Authorization "Bearer {$OLLAMA_API_KEY:__unset__}"
+    respond @denied "Unauthorized" 401
+
+    reverse_proxy ollama:11434
+}

--- a/docker/red/ollama/compose.yaml
+++ b/docker/red/ollama/compose.yaml
@@ -40,11 +40,36 @@ services:
           ollama pull "$$m" || echo "pull failed: $$m"
         done
         wait "$$pid"
-    # No host ports: Traefik reaches ollama:11434 over the shared `apps` network
-    # (https://ollama.tyriis.dev). `!reset` drops the ports inherited from the include.
+    # No host ports and no Traefik labels: the API-key gate (ollama-auth) is the only
+    # LAN/TLS entrypoint and reaches ollama over the shared `apps` network.
+    # `!reset` drops the ports inherited from the include.
     ports: !reset []
+
+  # Transparent OpenAI-style `Authorization: Bearer` gate in front of Ollama.
+  # Ollama has no auth of its own; this rejects requests without the shared key.
+  # The key comes from the SOPS-encrypted sops.env (doco-cd decrypts at deploy time and
+  # exports SOPS_ENV_FILE), never from a committed label.
+  ollama-auth:
+    image: caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+    cap_drop:
+      - ALL
+    container_name: ollama-auth
+    env_file:
+      - ${SOPS_ENV_FILE:-sops.env}
+    read_only: true
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges=true
+    tmpfs:
+      - /tmp
+      - /config
+      - /data
+    networks:
+      - apps
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ollama.rule=Host(`ollama.tyriis.dev`)"
       - "traefik.http.routers.ollama.entrypoints=websecure"
-      - "traefik.http.services.ollama.loadbalancer.server.port=11434"
+      - "traefik.http.services.ollama.loadbalancer.server.port=8080"

--- a/docker/red/ollama/sops.env
+++ b/docker/red/ollama/sops.env
@@ -1,0 +1,7 @@
+OLLAMA_API_KEY=ENC[AES256_GCM,data:Xg3aItvxdzX7aqY2HUkqNMH3daJLWQPhZwo8xu90AI8zf2rdJ2df+BMQmIgmExnV8BVeIj/o+luydggYvY1cpIkA2Q==,iv:oIRYSc1fpwBs8xBOPDmifxrC+5M/KZ6y+OFUDTFndWI=,tag:D7PH3ydQ4cxRBm7UGlFAow==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNE9sT25EZGVZOWQrNkF0\nT3RlRms0SHBML3ZVNzVMSUpHU2FVMkFINEZJCjhUY3pFU2RHMHRWSG12TVMwTHI5\ncUJoQ3NCSjJNZG9odmFURERubjYwNEEKLS0tIDNBTHF5RTU4VHFtb1EwemE0eEl4\nWmN1S0QzZmtyWHFiSHB4YXBQNUtIN0UKa5nMReNEDcxKgTiLaIMTxcVN7FX3gumA\nYdIFBeQzjTIprEthTlLuh/q7ZyxrdfnvchWetyrSbvSbQn3BkNWE2Q==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age16pcjw9pvhx2lnx382hrgcpydpjvjz6r8u22wflm228cakedrlgdqzlwx4s
+sops_lastmodified=2026-09-12T23:01:36Z
+sops_mac=ENC[AES256_GCM,data:7AGwsQwS05Opmh5nobnsimhiuCN9R99xcgj2twPy5PI6daHYk+Q+kPUXVQ6b8R5GbKrpbI4JN+gIyw0c3mZZrdFXumVvG5rmZdgeNvXo/flFRsx4ji91EwGRo8C4tGt84pudS4GlH2uTEyc2IfU426WtURKgFxKIGFzqrIbsR2k=,iv:TXsHigpZ/EzXUaGC1d/leH3ItY06xYsjHPFdMx3SIEg=,tag:Xu7ld+/iUh/5An1CP+FY/g==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/docs/decisions/0011-protect-red-ollama-with-openai-style-api-key.md
+++ b/docs/decisions/0011-protect-red-ollama-with-openai-style-api-key.md
@@ -1,0 +1,163 @@
+---
+status: accepted
+date: 2026-09-13
+decision-makers: [tyriis]
+---
+
+# Protect red's Ollama with an OpenAI-style API key
+
+## Context and Problem Statement
+
+`red` (the GPU workstation at `192.168.1.22`) serves Ollama at `https://ollama.tyriis.dev`
+through its LAN Traefik instance. The 2026-09-12 TLS design deliberately shipped without
+authentication: Traefik terminates TLS, but anything that can reach the LAN can call the API,
+consume the GPU, and list/pull models.
+
+Ollama has no built-in API key support; upstream explicitly recommends a reverse proxy for this
+(ollama/ollama#8536). Consumers speak the OpenAI contract — the `new-api` gateway on `bifrost`,
+OpenAI-compatible clients, and the Ollama Python/JS SDKs all send `Authorization: Bearer <key>`
+— so the gate has to accept that scheme. Open-source Traefik v3.7 has no native bearer/API-key
+middleware (`apiKey` and `JWT` are Traefik Hub/paid), so the gate must be built from a plugin,
+a forward-auth service, or a sidecar proxy.
+
+## Decision Drivers
+
+- Preserve the OpenAI-style `Authorization: Bearer <key>` contract end-to-end.
+- Do not execute third-party code inside the TLS terminator (Traefik).
+- No runtime dependency on `plugins.traefik.io`: Traefik loads plugins at startup and disables
+  plugin-backed middlewares if the download/validation call fails.
+- The key must never be committed in plaintext, placed in Compose labels, or visible in
+  `docker inspect`.
+- Fail closed if the key is unavailable.
+- Follow red's existing include-shim + SOPS + per-host `.env`/`sops.env` conventions and keep the
+  shared `docker/deploy/ollama` definition host-agnostic.
+- Minimal surface: gate only the Ollama route; `comfyui`/`gallery` are unchanged.
+
+## Considered Options
+
+- Caddy sidecar gate (`ollama-auth`) in front of Ollama
+- Traefik API-token plugin (`Aetherinox/traefik-api-token-middleware`)
+- Traefik API-key plugin (`Septima/traefik-api-key-auth`)
+- Traefik ForwardAuth to a small auth service / oauth2-proxy
+- nginx sidecar
+- Traefik Hub `apiKey` middleware
+- Traefik `BasicAuth`
+- No change (rely on LAN-only DNS + TLS)
+
+## Decision Outcome
+
+Chosen option: **Caddy sidecar gate (`ollama-auth`)**, because it preserves the OpenAI bearer
+contract while keeping all authentication code out of Traefik and avoiding the plugin-download
+coupling; Caddy is a stable, digest-pinnable official image and the same pattern already fronts
+every other red service.
+
+Concrete parameters:
+
+- `docker/red/ollama/compose.yaml` adds an `ollama-auth` service (`caddy:2.11-alpine`, digest-pinned)
+  on the shared `apps` network. It owns the `ollama.tyriis.dev` Traefik router
+  (`traefik.http.services.ollama.loadbalancer.server.port=8080`); the `ollama` service keeps no
+  Traefik labels and no published host ports.
+- `docker/red/ollama/Caddyfile` listens on `:8080` and rejects requests whose `Authorization`
+  header is not `Bearer <key>` with `401`, otherwise `reverse_proxy ollama:11434`.
+- The key `OLLAMA_API_KEY` is a generated `sk-<64 hex>` value stored SOPS-encrypted in
+  `docker/red/ollama/sops.env` (creation rule `docker/red/.*/sops\.env$`, red age key) and injected
+  into the container via `env_file: ${SOPS_ENV_FILE:-sops.env}`.
+- The Caddyfile uses the `:__unset__` default (`{$OLLAMA_API_KEY:__unset__}`) so the gate fails
+  closed if the env var is ever absent.
+- The gate is hardened like the rest of the host: `cap_drop: ALL`, `read_only`,
+  `no-new-privileges`, tmpfs for `/tmp`, `/config`, `/data`.
+
+### Consequences
+
+- Good, because the OpenAI-compatible contract is preserved end-to-end; Ollama's own `/v1` API is
+  unchanged behind the gate.
+- Good, because no third-party module runs in Traefik and there is no `plugins.traefik.io`
+  startup dependency.
+- Good, because the key stays out of git and out of container labels/`docker inspect`; rotation is
+  a single `sops docker/red/ollama/sops.env` edit.
+- Good, because it reuses red's established include-shim + SOPS conventions and leaves
+  `docker/deploy/ollama/compose.yaml` untouched for other hosts.
+- Neutral, because it adds one small container and one proxy hop on the `apps` network.
+- Bad, because the official `ollama` CLI cannot send an arbitrary bearer header — CLI use must
+  target a keyless local endpoint.
+- Bad, because consumers (`new-api`, Open WebUI, SDKs) must each be configured with both the key
+  and the TLS URL; the route now returns `401` by default.
+- Bad, because the Caddyfile env-var name must stay in sync with `sops.env`.
+
+### Confirmation
+
+- End-to-end against a fake upstream: without a key or with a wrong key → `401`; with the correct
+  key → `200` (including `/v1/models`); with `OLLAMA_API_KEY` unset → `401` (fail-closed).
+- `caddy validate` / `caddy adapt` on the committed Caddyfile is valid and emits the negated
+  `Authorization` matcher plus `reverse_proxy ollama:11434`.
+- `docker compose -f docker/red/ollama/compose.yaml config` shows `ollama-auth` carrying the router
+  labels, and no labels/ports on `ollama`.
+- Post-deploy: `curl https://ollama.tyriis.dev/api/tags` returns `401` without the key; `new-api`
+  lists and uses the red models with the key configured.
+
+## Pros and Cons of the Options
+
+### Caddy sidecar gate (ollama-auth)
+
+- Good, because it natively matches `Authorization: Bearer` and is a transparent pass-through for
+  Ollama's OpenAI-compatible API.
+- Good, because no third-party code executes in Traefik and there is no plugin download step.
+- Neutral, because it is one extra small container and one extra hop on the LAN.
+- Bad, because the bearer check is a plaintext constant comparison in the dynamic config (the key
+  is not hashed), and the Caddyfile must stay consistent with the env var.
+
+### Traefik API-token plugin (Aetherinox/traefik-api-token-middleware)
+
+- Good, because no extra container is needed; it is configured as a Traefik middleware and supports
+  `Authorization: Bearer`.
+- Neutral, because the token is a plaintext constant and the plugin is small/single-maintainer.
+- Bad, because third-party Go code runs inside the TLS terminator and Traefik downloads/validates
+  the plugin from `plugins.traefik.io` at every startup, disabling plugin middlewares if that call
+  fails (fail-open on route availability).
+
+### Traefik API-key plugin (Septima/traefik-api-key-auth)
+
+- Good, because the shape is identical to the Aetherinox option.
+- Bad, because it is stale (last release 2024-06) and carries the same in-process third-party code
+  and `plugins.traefik.io` startup coupling.
+
+### Traefik ForwardAuth to a small auth service / oauth2-proxy
+
+- Good, because `ForwardAuth` is a built-in Traefik middleware and centralizes auth decisions.
+- Neutral, because a tiny service can validate the `Authorization` header.
+- Bad, because it adds and maintains another service; oauth2-proxy is OIDC/browser-oriented and
+  overkill for one shared API key.
+
+### nginx sidecar
+
+- Good, because nginx is stable and equivalent to the Caddy gate.
+- Neutral, because the footprint is comparable.
+- Bad, because the bearer match is more verbose and offers no advantage over Caddy here.
+
+### Traefik Hub apiKey middleware
+
+- Good, because it is first-party and purpose-built, defaulting to `Authorization: Bearer`.
+- Bad, because it is a paid/closed product, so it is not viable on an OSS homelab Traefik.
+
+### Traefik BasicAuth
+
+- Good, because it is native and a single middleware.
+- Bad, because it is the wrong client contract — OpenAI clients send `Bearer sk-...`, not HTTP
+  Basic, so every consumer would have to change.
+
+### No change
+
+- Good, because it is zero work and access is already limited to private-IP DNS + TLS.
+- Bad, because TLS is transport security only; anything on the LAN can use the GPU and read/pull
+  models — the exact risk recorded in the 2026-09-12 spec.
+
+## More Information
+
+- Supersedes the "No authentication/authorization middleware" non-goal in
+  `docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md` (for `ollama` only).
+- Ollama has no built-in API key: <https://github.com/ollama/ollama/issues/8536>
+- Traefik OSS middleware list: <https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/overview/>
+- Traefik Hub `apiKey` (paid): <https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/apikey/>
+- Traefik plugin startup coupling: <https://github.com/traefik/traefik/issues/13005>
+- Caddy `header`/`not` matchers: <https://caddyserver.com/docs/caddyfile/matchers>
+- Ollama OpenAI compatibility: <https://docs.ollama.com/openai-compatibility>

--- a/docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md
+++ b/docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md
@@ -4,6 +4,9 @@
 - **Date:** 2026-09-12
 - **Amended:** 2026-09-13 — no proxied service publishes host ports (`ports: !reset []`); Jupyter is
   additionally routed at `jupyter.tyriis.dev` → `unsloth:8888`.
+- **Amended:** 2026-09-13 — `ollama.tyriis.dev` now requires an OpenAI-style `Authorization: Bearer`
+  key (ADR-0011); the "No authentication/authorization middleware" non-goal is superseded for
+  `ollama` only.
 - **Scope:** `docker/red/**`, `docker/deploy/node-exporter/compose.yaml`, `docker/.doco-cd.red.yaml`
 - **Supersedes:** the "Reverse proxy or TLS termination" non-goal in `docs/superpowers/specs/2026-08-16-unsloth-doco-cd-design.md`
 
@@ -43,7 +46,9 @@ should get the same treatment for the domain `tyriis.dev`.
   load-bearing: `/proc/net` resolves against the reader's netns, so moving it to a bridge silently
   breaks `netdev`/`netstat`/`sockstat`/`arp`/`conntrack` (see `prometheus/node_exporter` #2007,
   #3381). It stays as-is.
-- No authentication/authorization middleware. Traefik provides TLS, not auth.
+- No authentication/authorization middleware for `unsloth`, Jupyter, `comfyui`, or `gallery`; Traefik
+  provides TLS, not auth, and those services stay LAN-only. `ollama` is the exception: it is gated by
+  an OpenAI-style bearer key (ADR-0011).
 - No public exposure (LAN-only, private-IP DNS records).
 - No changes to `docker/deploy/traefik/compose.yaml` (bifrost-safe).
 
@@ -179,8 +184,9 @@ the SOPS-encrypted `docker/red/traefik/sops.env`, decrypted by doco-cd at deploy
 - **Bifrost isolation:** because red overrides `command` in its own shim, the shared Traefik
   definition is not modified; a `docker compose config` comparison for
   `docker/deploy/traefik/compose.yaml` guards this.
-- **TLS ≠ auth:** `ollama`, `comfyui`, `gallery` have no authentication; they remain LAN-only via
-  private-IP DNS.
+- **TLS ≠ auth:** `comfyui` and `gallery` have no authentication; they remain LAN-only via
+  private-IP DNS. `ollama` is gated by an OpenAI-style bearer key (ADR-0011), so requests without it
+  return `401`.
 - **Jupyter Host/remote access:** the May image's entrypoint came from a now-private repo, so its
   default Jupyter config is not fully auditable. If Jupyter rejects the proxied `Host` header
   (`jupyter.tyriis.dev`), the fallback is to mount a `jupyter_lab_config.py` setting


### PR DESCRIPTION
## Summary

Prevent unauthenticated access to `red`'s Ollama by requiring an **OpenAI-style API key** (`Authorization: Bearer sk-...`) on `https://ollama.tyriis.dev`.

OSS Traefik v3.7 has no native bearer/API-key middleware (Hub-only), so a digest-pinned **Caddy guard** (`ollama-auth`) fronts `ollama:11434` and returns `401` without the key. No third-party plugin runs inside Traefik and there is no `plugins.traefik.io` startup dependency.

- `ollama-auth` (Caddy) owns the `ollama.tyriis.dev` router; `ollama` keeps no labels and no host ports.
- Key is a generated `sk-<64 hex>` stored **SOPS-encrypted** in `docker/red/ollama/sops.env` (red age key, rule already in `.sops.yaml`); never committed plaintext, never in Compose labels.
- Gate **fails closed**: `{$OLLAMA_API_KEY:__unset__}` default.
- Hardened: `cap_drop: ALL`, `read_only`, `no-new-privileges`, tmpfs `/tmp /config /data`.
- ADR-0011 records the decision and supersedes the `2026-09-12-red-traefik-tls-termination` spec's "no authentication" non-goal (for `ollama` only).

## Files

- `docker/red/ollama/Caddyfile` — **new** bearer gate.
- `docker/red/ollama/compose.yaml` — add `ollama-auth`; move router labels off `ollama`.
- `docker/red/ollama/sops.env` — **new**, SOPS-encrypted `OLLAMA_API_KEY`.
- `docker/red/README.md` — gate docs, client usage, rotation.
- `docs/decisions/0011-protect-red-ollama-with-openai-style-api-key.md` — **new** ADR.
- `docs/superpowers/specs/2026-09-12-red-traefik-tls-termination-design.md` — mark auth non-goal superseded for `ollama`.

## Verification

- **End-to-end** against a fake upstream: no key / wrong key → `401`; correct key → `200` (including `/v1/models`); `OLLAMA_API_KEY` unset → `401` (fail-closed).
- `caddy validate` / `caddy adapt` → valid; emits negated `Authorization` matcher + `reverse_proxy ollama:11434`.
- `docker compose -f docker/red/ollama/compose.yaml config` → `ollama-auth` carries the router labels; `ollama` has no labels/ports.
- `pre-commit` → all hooks pass.

## Operator follow-up (not in repo)

- In `new-api`, add the upstream `https://ollama.tyriis.dev/v1` with the API key as the token. (The old `olla` endpoint pointing at `192.168.1.22:11434` is already dead — `olla` is being retired.)
- Note: the official `ollama` CLI cannot send bearer headers; it must target a keyless local endpoint.
