### PR TITLE
fix(red): unblock ollama-auth caddy and unsloth routers

### DIFF
--- a/docker/red/ollama/compose.yaml
+++ b/docker/red/ollama/compose.yaml
@@ -53,6 +53,13 @@ services:
     image: caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
     cap_drop:
       - ALL
+    # The official Caddy image ships /usr/bin/caddy with the file capability
+    # cap_net_bind_service=ep. With an empty capability bounding set (cap_drop: ALL) the
+    # kernel refuses to execve it ("exec /usr/bin/caddy: operation not permitted"), so exactly
+    # that one capability is added back. The listener is :8080 (unprivileged) — nothing more
+    # is needed.
+    cap_add:
+      - NET_BIND_SERVICE
     container_name: ollama-auth
     env_file:
       - ${SOPS_ENV_FILE:-sops.env}

--- a/docker/red/unsloth/compose.yaml
+++ b/docker/red/unsloth/compose.yaml
@@ -22,11 +22,17 @@ services:
     # No host ports: Traefik reaches Studio (:8000) and Jupyter (:8888) over the
     # shared `apps` network. `!reset` drops the ports inherited from the include.
     ports: !reset []
+    # This container exposes TWO Traefik services (`unsloth` and `jupyter`), so each router
+    # must name its service explicitly — Traefik refuses to auto-link a router when the
+    # container declares more than one service ("cannot be linked automatically with multiple
+    # Services"), which otherwise leaves both routers without a service and returns 404.
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.unsloth.rule=Host(`unsloth.tyriis.dev`)"
       - "traefik.http.routers.unsloth.entrypoints=websecure"
+      - "traefik.http.routers.unsloth.service=unsloth"
       - "traefik.http.services.unsloth.loadbalancer.server.port=8000"
       - "traefik.http.routers.jupyter.rule=Host(`jupyter.tyriis.dev`)"
       - "traefik.http.routers.jupyter.entrypoints=websecure"
+      - "traefik.http.routers.jupyter.service=jupyter"
       - "traefik.http.services.jupyter.loadbalancer.server.port=8888"

--- a/docs/decisions/0011-protect-red-ollama-with-openai-style-api-key.md
+++ b/docs/decisions/0011-protect-red-ollama-with-openai-style-api-key.md
@@ -65,7 +65,11 @@ Concrete parameters:
 - The Caddyfile uses the `:__unset__` default (`{$OLLAMA_API_KEY:__unset__}`) so the gate fails
   closed if the env var is ever absent.
 - The gate is hardened like the rest of the host: `cap_drop: ALL`, `read_only`,
-  `no-new-privileges`, tmpfs for `/tmp`, `/config`, `/data`.
+  `no-new-privileges`, tmpfs for `/tmp`, `/config`, `/data`. `NET_BIND_SERVICE` is added back via
+  `cap_add` because the official Caddy image ships `/usr/bin/caddy` with the file capability
+  `cap_net_bind_service=ep`; with an empty bounding set the kernel refuses to `execve` it
+  (`operation not permitted`). The listener is `:8080` (unprivileged), so no other capability is
+  needed.
 
 ### Consequences
 


### PR DESCRIPTION
## Summary

Fixes the live `404` on `https://ollama.tyriis.dev` (and `https://unsloth.tyriis.dev`) on `red`.

Two independent root causes, both found from live evidence on the host:

### 1. `ollama-auth` crash-loop (causes the ollama 404)
The container was restarting with:

```
exec /usr/bin/caddy: operation not permitted
```

The official Caddy image ships `/usr/bin/caddy` with the **file capability** `cap_net_bind_service=ep`. With `cap_drop: ALL` the capability bounding set is empty, so the kernel refuses to `execve` the binary — `ollama-auth` never started, so Traefik had no `ollama` router and returned 404.

**Fix:** add exactly `NET_BIND_SERVICE` back via `cap_add`. The listener is `:8080` (unprivileged); no other capability is required. Verified by running the exact hardened flag set: `serving initial configuration`, container stays up.

### 2. `unsloth`/`jupyter` routers had no service (causes the unsloth 404)
Traefik logged repeatedly:

```
Router unsloth cannot be linked automatically with multiple Services: ["jupyter" "unsloth"]
Router jupyter cannot be linked automatically with multiple Services: ["unsloth" "jupyter"]
```

The `unsloth` container declares two Traefik services, which disables auto-linking — both routers ended up without a service and returned 404 (pre-existing, from the Jupyter routing change).

**Fix:** add explicit `traefik.http.routers.<name>.service=<name>` labels for both routers.

## Files

- `docker/red/ollama/compose.yaml` — `cap_add: [NET_BIND_SERVICE]` + explanatory comment.
- `docker/red/unsloth/compose.yaml` — explicit router→service labels + comment.
- `docs/decisions/0011-...md` — record the Caddy file-capability constraint.

## Verification

- Reproduced the EPERM minimally (`--cap-drop ALL` → fail; `--cap-drop ALL --cap-add NET_BIND_SERVICE` → success).
- Full hardened Caddy run (`cap_drop ALL`, `cap_add NET_BIND_SERVICE`, `read_only`, `no-new-privileges`, tmpfs `/tmp /config /data`): starts and serves.
- `docker compose config` shows `cap_add: [NET_BIND_SERVICE]` and both explicit `routers.*.service` labels.
- `pre-commit` passes.
- Post-deploy on `red`: `ollama.tyriis.dev` → `401` (gate up) instead of `404`; `unsloth.tyriis.dev` → `302/200`.
